### PR TITLE
fix: install script patching wrong config file

### DIFF
--- a/bin/install.e-bash.sh
+++ b/bin/install.e-bash.sh
@@ -349,18 +349,18 @@ function repo_uninstall() {
     ((uninstall_steps++))
   fi
 
-  # Clean .mise.toml if it exists
-  if [ -f ".mise.toml" ]; then
-    if grep -q "E_BASH" ".mise.toml"; then
+  # Clean mise.toml if it exists
+  if [ -f "mise.toml" ]; then
+    if grep -q "E_BASH" "mise.toml"; then
       if [ "$DRY_RUN" = true ]; then
-        echo -e "${CYAN}dry run: clean .mise.toml configuration${NC}"
+        echo -e "${CYAN}dry run: clean mise.toml configuration${NC}"
       else
         # Use a simple and reliable approach
         # Step 1: Remove the e-bash comment line
-        sed -i.bak '/# e-bash scripts configuration/d' ".mise.toml"
+        sed -i.bak '/# e-bash scripts configuration/d' "mise.toml"
 
         # Step 2: Remove E_BASH and _.path lines
-        sed -i '/E_BASH.*\.scripts/d; /_.path.*\.scripts/d' ".mise.toml"
+        sed -i '/E_BASH.*\.scripts/d; /_.path.*\.scripts/d' "mise.toml"
 
         # Step 3: Remove empty [[env]] and [env]] sections using awk
         awk '
@@ -390,10 +390,10 @@ function repo_uninstall() {
         }
         # Print all other lines
         { print }
-        ' ".mise.toml" >".mise.toml.tmp" && mv ".mise.toml.tmp" ".mise.toml"
+        ' "mise.toml" >"mise.toml.tmp" && mv "mise.toml.tmp" "mise.toml"
 
-        rm -f ".mise.toml.bak"
-        echo -e "${GREEN}Cleaned .mise.toml configuration${NC}"
+        rm -f "mise.toml.bak"
+        echo -e "${GREEN}Cleaned mise.toml configuration${NC}"
       fi
       ((uninstall_steps++))
     fi
@@ -952,13 +952,13 @@ function post_installation_steps() {
     echo -e "${prefix}${GRAY}Skipping DIRENV integration. No ${YELLOW}${PWD}/.envrc${GRAY} file.${NC}" >&2
   fi
 
-  # Check for .mise.toml file and update it if found
-  if [ -f ".mise.toml" ] && [ "$DRY_RUN" == false ]; then
+  # Check for mise.toml file and update it if found
+  if [ -f "mise.toml" ] && [ "$DRY_RUN" == false ]; then
     update_mise_configuration
   else
     local prefix=""
     [ "$DRY_RUN" == true ] && prefix="${CYAN}dry run: ${NC}"
-    echo -e "${prefix}${GRAY}Skipping MISE integration. No ${YELLOW}${PWD}/.mise.toml${GRAY} file.${NC}" >&2
+    echo -e "${prefix}${GRAY}Skipping MISE integration. No ${YELLOW}${PWD}/mise.toml${GRAY} file.${NC}" >&2
   fi
 
   # Check for bin directory and copy installer script
@@ -1093,10 +1093,10 @@ function update_mise_configuration() {
         print
         exit
       }
-    ' ".mise.toml"
+    ' "mise.toml"
   }
 
-  # Helper: Update existing E_BASH path in .mise.toml
+  # Helper: Update existing E_BASH path in mise.toml
   update_mise_path() {
     local old_path="$1"
     local new_path="$2"
@@ -1104,13 +1104,13 @@ function update_mise_configuration() {
     echo -e "${BLUE}Updating MISE configuration from ${YELLOW}${old_path}${BLUE} to ${YELLOW}${new_path}${NC}"
 
     # Update E_BASH path
-    sed -i.bak "s|E_BASH = \"{{config_root}}/${old_path}\"|E_BASH = \"{{config_root}}/${new_path}\"|g" ".mise.toml"
+    sed -i.bak "s|E_BASH = \"{{config_root}}/${old_path}\"|E_BASH = \"{{config_root}}/${new_path}\"|g" "mise.toml"
 
     # Update _.path entries
-    sed -i.bak "s|\"{{config_root}}/${old_path}\"|\"{{config_root}}/${new_path}\"|g" ".mise.toml"
+    sed -i.bak "s|\"{{config_root}}/${old_path}\"|\"{{config_root}}/${new_path}\"|g" "mise.toml"
 
-    rm -f ".mise.toml.bak"
-    echo -e "${GREEN}Updated e-bash configuration in ${YELLOW}${PWD}/.mise.toml${NC}"
+    rm -f "mise.toml.bak"
+    echo -e "${GREEN}Updated e-bash configuration in ${YELLOW}${PWD}/mise.toml${NC}"
     echo -e "${YELLOW}Run 'mise trust' to apply the changes${NC}"
   }
 
@@ -1122,7 +1122,7 @@ function update_mise_configuration() {
       /^\[env\]$/ || /^\[\[env\]\]$/ { in_env=1; next }
       /^\[/ { in_env=0 }
       in_env && /^[[:space:]]*_.path[[:space:]]*=/ { print "true"; exit }
-    ' ".mise.toml")
+    ' "mise.toml")
     [ "$result" = "true" ]
   }
 
@@ -1138,7 +1138,7 @@ function update_mise_configuration() {
         print
         exit
       }
-    ' ".mise.toml"
+    ' "mise.toml"
   }
 
   # Helper: Check if a specific path entry exists in the existing paths
@@ -1153,7 +1153,7 @@ function update_mise_configuration() {
   }
 
   # Check if E_BASH is already configured in any [env] or [[env]] section
-  if [ -f ".mise.toml" ]; then
+  if [ -f "mise.toml" ]; then
     local existing_value=$(get_mise_env_value "E_BASH")
     if [ -n "$existing_value" ]; then
       # Extract the directory path from the existing value
@@ -1162,7 +1162,7 @@ function update_mise_configuration() {
 
       # If the path matches current SCRIPTS_DIR, skip
       if [ "$current_path" = "$SCRIPTS_DIR" ]; then
-        echo -e "${GRAY}Skipping MISE integration. E_BASH already configured in ${YELLOW}${PWD}/.mise.toml${NC}"
+        echo -e "${GRAY}Skipping MISE integration. E_BASH already configured in ${YELLOW}${PWD}/mise.toml${NC}"
         return 0
       fi
 
@@ -1176,9 +1176,9 @@ function update_mise_configuration() {
   local has_env_table=false # [env] - single table
   local has_env_array=false # [[env]] - array of tables
 
-  if [ -f ".mise.toml" ]; then
-    grep -q "^\\[env\\]" ".mise.toml" && has_env_table=true
-    grep -q "^\\[\\[env\\]\\]" ".mise.toml" && has_env_array=true
+  if [ -f "mise.toml" ]; then
+    grep -q "^\\[env\\]" "mise.toml" && has_env_table=true
+    grep -q "^\\[\\[env\\]\\]" "mise.toml" && has_env_array=true
   fi
 
   # Check if we already have _.path entries and if our entries are already included
@@ -1218,12 +1218,12 @@ function update_mise_configuration() {
         # Create new _.path with our entries
         echo "_.path = [\"{{config_root}}/${SCRIPTS_DIR}\", \"{{config_root}}/bin\"]"
       fi
-    } >>".mise.toml"
-    echo -e "${GREEN}Added e-bash configuration as new [[env]] entry in ${YELLOW}${PWD}/.mise.toml${NC}"
+    } >>"mise.toml"
+    echo -e "${GREEN}Added e-bash configuration as new [[env]] entry in ${YELLOW}${PWD}/mise.toml${NC}"
   elif [ "$has_env_table" = true ]; then
     # Insert into existing [env] section (before next section or EOF)
     # Find the line number where [env] section ends
-    local env_end=$(awk '/^\[env\]/{start=NR; next} start && /^\[/{print NR-1; found=1; exit} END{if(start && !found) print NR}' ".mise.toml")
+    local env_end=$(awk '/^\[env\]/{start=NR; next} start && /^\[/{print NR-1; found=1; exit} END{if(start && !found) print NR}' "mise.toml")
 
     # Handle _.path merging for [env] section
     local new_path=""
@@ -1256,15 +1256,15 @@ function update_mise_configuration() {
     # Create temp file with insertion, removing existing _.path lines
     {
       # Output lines before the insertion point, excluding existing _.path
-      head -n "$env_end" ".mise.toml" | grep -v "^[[:space:]]*_.path[[:space:]]*="
+      head -n "$env_end" "mise.toml" | grep -v "^[[:space:]]*_.path[[:space:]]*="
       echo "# e-bash scripts configuration"
       echo "E_BASH = \"{{config_root}}/${SCRIPTS_DIR}\""
       echo "_.path = ${new_path}"
-      tail -n +$((env_end + 1)) ".mise.toml"
-    } >".mise.toml.tmp"
+      tail -n +$((env_end + 1)) "mise.toml"
+    } >"mise.toml.tmp"
 
-    mv ".mise.toml.tmp" ".mise.toml"
-    echo -e "${GREEN}Added e-bash configuration to existing [env] section in ${YELLOW}${PWD}/.mise.toml${NC}"
+    mv "mise.toml.tmp" "mise.toml"
+    echo -e "${GREEN}Added e-bash configuration to existing [env] section in ${YELLOW}${PWD}/mise.toml${NC}"
   else
     # Create new [env] table (prefer single table for simplicity)
     {
@@ -1273,8 +1273,8 @@ function update_mise_configuration() {
       echo "[env]"
       echo "E_BASH = \"{{config_root}}/${SCRIPTS_DIR}\""
       echo "_.path = [\"{{config_root}}/${SCRIPTS_DIR}\", \"{{config_root}}/bin\"]"
-    } >>".mise.toml"
-    echo -e "${GREEN}Added e-bash configuration to ${YELLOW}${PWD}/.mise.toml${NC}"
+    } >>"mise.toml"
+    echo -e "${GREEN}Added e-bash configuration to ${YELLOW}${PWD}/mise.toml${NC}"
   fi
 
   echo -e "${YELLOW}Run 'mise trust' to apply the changes${NC}"

--- a/bin/install.e-bash.sh
+++ b/bin/install.e-bash.sh
@@ -15,11 +15,17 @@ set -e
 shopt -s extdebug # enable extended debugging
 
 # Configuration.
-readonly REMOTE_NAME="e-bash"
-readonly REMOTE_MASTER="master"
-readonly REMOTE_URL="https://github.com/OleksandrKucherenko/e-bash.git"
-readonly REMOTE_INSTALL_SH="https://raw.githubusercontent.com/OleksandrKucherenko/e-bash/master/bin/install.e-bash.sh"
-readonly REMOTE_SHORT="https://git.new/e-bash"
+# These can be overridden via environment variables for testing or alternative repositories:
+# - E_BASH_REMOTE_NAME: Git remote name (default: "e-bash")
+# - E_BASH_REMOTE_MASTER: Master branch name (default: "master")
+# - E_BASH_REMOTE_URL: Git repository URL
+# - E_BASH_REMOTE_INSTALL_SH: Installation script URL
+# - E_BASH_REMOTE_SHORT: Short URL for curl installation
+readonly REMOTE_NAME="${E_BASH_REMOTE_NAME:-e-bash}"
+readonly REMOTE_MASTER="${E_BASH_REMOTE_MASTER:-master}"
+readonly REMOTE_URL="${E_BASH_REMOTE_URL:-https://github.com/OleksandrKucherenko/e-bash.git}"
+readonly REMOTE_INSTALL_SH="${E_BASH_REMOTE_INSTALL_SH:-https://raw.githubusercontent.com/OleksandrKucherenko/e-bash/master/bin/install.e-bash.sh}"
+readonly REMOTE_SHORT="${E_BASH_REMOTE_SHORT:-https://git.new/e-bash}"
 readonly TEMP_BRANCH="e-bash-temp"
 readonly SCRIPTS_BRANCH="e-bash-scripts"
 readonly DEFAULT_SCRIPTS_DIR=".scripts"

--- a/docs/public/installation.md
+++ b/docs/public/installation.md
@@ -20,6 +20,49 @@ This document provides detailed test scenarios for installing, upgrading, and ma
   - [Scenario 12: Installation with insufficient permissions](#scenario-12-installation-with-insufficient-permissions)
   - [Scenario 13: Network failure during installation](#scenario-13-network-failure-during-installation)
 
+## Environment Variables
+
+The installation script supports environment variable overrides for advanced use cases such as:
+- Installing from a forked or alternative repository
+- Using a company-internal mirror of the e-bash repository
+- Testing with a local git repository
+- Continuous integration and automated testing
+
+### Available Environment Variables
+
+| Variable | Default Value | Description |
+|----------|--------------|-------------|
+| `E_BASH_REMOTE_NAME` | `e-bash` | Git remote name used for the e-bash repository |
+| `E_BASH_REMOTE_MASTER` | `master` | Master branch name in the remote repository |
+| `E_BASH_REMOTE_URL` | `https://github.com/OleksandrKucherenko/e-bash.git` | Git repository URL for cloning and fetching |
+| `E_BASH_REMOTE_INSTALL_SH` | `https://raw.githubusercontent.com/OleksandrKucherenko/e-bash/master/bin/install.e-bash.sh` | URL to the installation script |
+| `E_BASH_REMOTE_SHORT` | `https://git.new/e-bash` | Short URL for quick installation via curl |
+
+### Usage Examples
+
+#### Installing from a Fork
+
+```bash
+export E_BASH_REMOTE_URL="https://github.com/mycompany/e-bash.git"
+export E_BASH_REMOTE_INSTALL_SH="https://raw.githubusercontent.com/mycompany/e-bash/master/bin/install.e-bash.sh"
+curl -sSL "$E_BASH_REMOTE_INSTALL_SH" | bash -s -- install
+```
+
+#### Installing from a Local Repository (Testing)
+
+```bash
+export E_BASH_REMOTE_URL="/path/to/local/e-bash.git"
+./bin/install.e-bash.sh install
+```
+
+#### Using with Different Branch Name
+
+```bash
+export E_BASH_REMOTE_MASTER="main"
+export E_BASH_REMOTE_URL="https://github.com/mycompany/e-bash.git"
+./bin/install.e-bash.sh install
+```
+
 ## Review of the Script Actions
 
 The following state diagram illustrates the logic flow of the `install.e-bash.sh` script, showing the various states and transitions during the installation, upgrade, and rollback processes.

--- a/spec/installation_spec.sh
+++ b/spec/installation_spec.sh
@@ -194,8 +194,8 @@ Describe 'bin/install.e-bash.sh /'
     End
 
     It 'should integrate with mise.toml if file exists'
-      touch .mise.toml
-      git add .mise.toml
+      touch mise.toml
+      git add mise.toml
       git commit --no-gpg-sign -m "Add mise.toml" -q 2>/dev/null || git commit -m "Add mise.toml" -q
 
       When run ./install.e-bash.sh install
@@ -204,18 +204,18 @@ Describe 'bin/install.e-bash.sh /'
       The result of function no_colors_error should include "installer: e-bash scripts"
       The result of function no_colors_output should include "Installation complete"
       The result of function no_colors_output should include "Added e-bash configuration to"
-      The result of function no_colors_output should include ".mise.toml"
-      The file ".mise.toml" should be present
-      The contents of file ".mise.toml" should include "E_BASH"
-      The contents of file ".mise.toml" should include "{{config_root}}/.scripts"
-      The contents of file ".mise.toml" should include "_.path"
+      The result of function no_colors_output should include "mise.toml"
+      The file "mise.toml" should be present
+      The contents of file "mise.toml" should include "E_BASH"
+      The contents of file "mise.toml" should include "{{config_root}}/.scripts"
+      The contents of file "mise.toml" should include "_.path"
     End
 
     It 'should not modify mise.toml if it already has E_BASH configuration'
-      touch .mise.toml
-      echo '[env]' >>.mise.toml
-      echo 'E_BASH = "{{config_root}}/.scripts"' >>.mise.toml
-      git add .mise.toml
+      touch mise.toml
+      echo '[env]' >>mise.toml
+      echo 'E_BASH = "{{config_root}}/.scripts"' >>mise.toml
+      git add mise.toml
       git commit --no-gpg-sign -m "Add mise.toml with E_BASH" -q 2>/dev/null || git commit -m "Add mise.toml with E_BASH" -q
 
       When run ./install.e-bash.sh install
@@ -227,16 +227,16 @@ Describe 'bin/install.e-bash.sh /'
     End
 
     It 'should insert into existing [env] section before other sections'
-      touch .mise.toml
-      echo '[env]' >>.mise.toml
-      echo 'NODE_ENV = "development"' >>.mise.toml
-      echo '' >>.mise.toml
-      echo '[tools]' >>.mise.toml
-      echo 'node = "20"' >>.mise.toml
-      git add .mise.toml
+      touch mise.toml
+      echo '[env]' >>mise.toml
+      echo 'NODE_ENV = "development"' >>mise.toml
+      echo '' >>mise.toml
+      echo '[tools]' >>mise.toml
+      echo 'node = "20"' >>mise.toml
+      git add mise.toml
       git commit --no-gpg-sign -m "Add mise.toml with [env] and [tools]" -q 2>/dev/null || git commit -m "Add mise.toml with [env] and [tools]" -q
 
-      When run sh -c './install.e-bash.sh install && echo "=== FILE CONTENT ===" && cat .mise.toml'
+      When run sh -c './install.e-bash.sh install && echo "=== FILE CONTENT ===" && cat mise.toml'
 
       The status should be success
       The result of function no_colors_error should include "installer: e-bash scripts"
@@ -251,10 +251,10 @@ Describe 'bin/install.e-bash.sh /'
     End
 
     It 'should handle mise.toml with [[env]] array of tables'
-      touch .mise.toml
-      echo '[[env]]' >>.mise.toml
-      echo 'NODE_ENV = "development"' >>.mise.toml
-      git add .mise.toml
+      touch mise.toml
+      echo '[[env]]' >>mise.toml
+      echo 'NODE_ENV = "development"' >>mise.toml
+      git add mise.toml
       git commit --no-gpg-sign -m "Add mise.toml with [[env]]" -q 2>/dev/null || git commit -m "Add mise.toml with [[env]]" -q
 
       When run ./install.e-bash.sh install
@@ -263,17 +263,17 @@ Describe 'bin/install.e-bash.sh /'
       The result of function no_colors_error should include "installer: e-bash scripts"
       The result of function no_colors_output should include "Installation complete"
       The result of function no_colors_output should include "Added e-bash configuration as new [[env]] entry"
-      The file ".mise.toml" should be present
-      The contents of file ".mise.toml" should include "[[env]]"
-      The contents of file ".mise.toml" should include "E_BASH"
-      The contents of file ".mise.toml" should include "NODE_ENV"
+      The file "mise.toml" should be present
+      The contents of file "mise.toml" should include "[[env]]"
+      The contents of file "mise.toml" should include "E_BASH"
+      The contents of file "mise.toml" should include "NODE_ENV"
     End
 
     It 'should not modify mise.toml with [[env]] if E_BASH exists'
-      touch .mise.toml
-      echo '[[env]]' >>.mise.toml
-      echo 'E_BASH = "{{config_root}}/.scripts"' >>.mise.toml
-      git add .mise.toml
+      touch mise.toml
+      echo '[[env]]' >>mise.toml
+      echo 'E_BASH = "{{config_root}}/.scripts"' >>mise.toml
+      git add mise.toml
       git commit --no-gpg-sign -m "Add mise.toml with [[env]] and E_BASH" -q 2>/dev/null || git commit -m "Add mise.toml with [[env]] and E_BASH" -q
 
       When run ./install.e-bash.sh install
@@ -1062,57 +1062,57 @@ Describe 'bin/install.e-bash.sh /'
       The file ".envrc" should not include "PATH_add"
     End
 
-    It 'should clean .mise.toml E_BASH configuration with [env]'
+    It 'should clean mise.toml E_BASH configuration with [env]'
       mock_install
-      touch .mise.toml
-      echo '# e-bash scripts configuration' >>.mise.toml
-      echo '[env]' >>.mise.toml
-      echo 'E_BASH = "{{config_root}}/.scripts"' >>.mise.toml
-      echo '_.path = ["{{config_root}}/.scripts"]' >>.mise.toml
+      touch mise.toml
+      echo '# e-bash scripts configuration' >>mise.toml
+      echo '[env]' >>mise.toml
+      echo 'E_BASH = "{{config_root}}/.scripts"' >>mise.toml
+      echo '_.path = ["{{config_root}}/.scripts"]' >>mise.toml
 
       When run ./install.e-bash.sh uninstall --confirm
 
       The status should be success
       The result of function no_colors_error should include "installer: e-bash scripts"
       The result of function no_colors_output should include "Uninstall complete!"
-      The file ".mise.toml" should not include "E_BASH"
-      The file ".mise.toml" should not include "_.path"
+      The file "mise.toml" should not include "E_BASH"
+      The file "mise.toml" should not include "_.path"
     End
 
-    It 'should clean .mise.toml E_BASH configuration with [[env]]'
+    It 'should clean mise.toml E_BASH configuration with [[env]]'
       mock_install
-      touch .mise.toml
-      echo '# e-bash scripts configuration' >>.mise.toml
-      echo '[[env]]' >>.mise.toml
-      echo 'E_BASH = "{{config_root}}/.scripts"' >>.mise.toml
-      echo '_.path = ["{{config_root}}/.scripts"]' >>.mise.toml
+      touch mise.toml
+      echo '# e-bash scripts configuration' >>mise.toml
+      echo '[[env]]' >>mise.toml
+      echo 'E_BASH = "{{config_root}}/.scripts"' >>mise.toml
+      echo '_.path = ["{{config_root}}/.scripts"]' >>mise.toml
 
       When run ./install.e-bash.sh uninstall --confirm
 
       The status should be success
       The result of function no_colors_error should include "installer: e-bash scripts"
       The result of function no_colors_output should include "Uninstall complete!"
-      The file ".mise.toml" should not include "E_BASH"
-      The file ".mise.toml" should not include "_.path"
+      The file "mise.toml" should not include "E_BASH"
+      The file "mise.toml" should not include "_.path"
     End
 
     It 'should preserve other [[env]] entries when cleaning'
       mock_install
-      touch .mise.toml
-      echo '[[env]]' >>.mise.toml
-      echo 'NODE_ENV = "development"' >>.mise.toml
-      echo '' >>.mise.toml
-      echo '# e-bash scripts configuration' >>.mise.toml
-      echo '[[env]]' >>.mise.toml
-      echo 'E_BASH = "{{config_root}}/.scripts"' >>.mise.toml
-      echo '_.path = ["{{config_root}}/.scripts"]' >>.mise.toml
+      touch mise.toml
+      echo '[[env]]' >>mise.toml
+      echo 'NODE_ENV = "development"' >>mise.toml
+      echo '' >>mise.toml
+      echo '# e-bash scripts configuration' >>mise.toml
+      echo '[[env]]' >>mise.toml
+      echo 'E_BASH = "{{config_root}}/.scripts"' >>mise.toml
+      echo '_.path = ["{{config_root}}/.scripts"]' >>mise.toml
 
-      When run sh -c './install.e-bash.sh uninstall --confirm && echo "=== FILE CONTENT CHECK ===" && cat .mise.toml'
+      When run sh -c './install.e-bash.sh uninstall --confirm && echo "=== FILE CONTENT CHECK ===" && cat mise.toml'
 
       The status should be success
       The result of function no_colors_error should include "installer: e-bash scripts"
       The result of function no_colors_output should include "Uninstall complete!"
-      The file ".mise.toml" should not include "E_BASH"
+      The file "mise.toml" should not include "E_BASH"
       The output should include "NODE_ENV"
     End
 
@@ -1280,19 +1280,19 @@ Describe 'bin/install.e-bash.sh /'
       The contents of file ".envrc" should include "E_BASH="
     End
 
-    It 'should update .mise.toml with custom directory path'
-      # Create empty .mise.toml (no E_BASH configuration yet)
-      touch .mise.toml
-      git add .mise.toml
-      git commit --no-gpg-sign -m "Add .mise.toml" -q 2>/dev/null || git commit -m "Add .mise.toml" -q
+    It 'should update mise.toml with custom directory path'
+      # Create empty mise.toml (no E_BASH configuration yet)
+      touch mise.toml
+      git add mise.toml
+      git commit --no-gpg-sign -m "Add mise.toml" -q 2>/dev/null || git commit -m "Add mise.toml" -q
 
       When run ./install.e-bash.sh install --directory .ebash-tools
 
       The status should be success
       The result of function no_colors_output should include "Installation complete"
-      The file ".mise.toml" should be present
-      The contents of file ".mise.toml" should include ".ebash-tools"
-      The contents of file ".mise.toml" should include "E_BASH"
+      The file "mise.toml" should be present
+      The contents of file "mise.toml" should include ".ebash-tools"
+      The contents of file "mise.toml" should include "E_BASH"
     End
 
     It 'should require argument for --directory flag'
@@ -1370,15 +1370,15 @@ Describe 'bin/install.e-bash.sh /'
       The dir ".custom-ebash" should be present
     End
 
-    It 'should update .mise.toml when switching from default to custom directory'
+    It 'should update mise.toml when switching from default to custom directory'
       # First install with default directory
-      touch .mise.toml
-      git add .mise.toml
-      git commit --no-gpg-sign -m "Add .mise.toml" -q 2>/dev/null || git commit -m "Add .mise.toml" -q
+      touch mise.toml
+      git add mise.toml
+      git commit --no-gpg-sign -m "Add mise.toml" -q 2>/dev/null || git commit -m "Add mise.toml" -q
       ./install.e-bash.sh install 2>/dev/null >/dev/null
 
-      # Verify .mise.toml has .scripts path
-      grep -q "E_BASH.*{{config_root}}/.scripts" .mise.toml || exit 1
+      # Verify mise.toml has .scripts path
+      grep -q "E_BASH.*{{config_root}}/.scripts" mise.toml || exit 1
 
       # Now upgrade with custom directory (treated as fresh install to new location)
       When run ./install.e-bash.sh upgrade --directory .ebash-alt
@@ -1387,10 +1387,10 @@ Describe 'bin/install.e-bash.sh /'
       # When switching directories, it's treated as a fresh install to new location
       The result of function no_colors_output should include "e-bash scripts not installed. Installing instead."
       The result of function no_colors_output should include "Installation complete"
-      # Config gets added to .mise.toml during install
+      # Config gets added to mise.toml during install
       The result of function no_colors_output should include "Added e-bash configuration to"
-      The result of function no_colors_output should include ".mise.toml"
-      The contents of file ".mise.toml" should include "{{config_root}}/.ebash-alt"
+      The result of function no_colors_output should include "mise.toml"
+      The contents of file "mise.toml" should include "{{config_root}}/.ebash-alt"
       The dir ".ebash-alt" should be present
     End
 


### PR DESCRIPTION
The install script was incorrectly looking for `.mise.toml` (hidden file with leading dot) when it should look for `mise.toml` (without dot). According to mise documentation, the config file should be `mise.toml`.

Changes:
- Updated bin/install.e-bash.sh to use 'mise.toml' instead of '.mise.toml'
- Updated spec/installation_spec.sh to test 'mise.toml' instead of '.mise.toml'

Fixes issue where mise integration would never trigger because the script was looking for the wrong filename.