### PR TITLE
feat: self update, ability to granularly update the e-bash 

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -62,7 +62,8 @@
       "Bash(perl -i -pe:*)",
       "WebFetch(domain:lefthook.dev)",
       "Bash(mkdir:*)",
-      "Read(//home/linuxbrew/.linuxbrew/Cellar/shellspec/0.28.1/lib/shellspec/lib/**)"
+      "Read(//home/linuxbrew/.linuxbrew/Cellar/shellspec/0.28.1/lib/shellspec/lib/**)",
+      "Bash(array:qsort \"compare:versions\" \"2.0.0\" \"1.0.0\" \"1.5.0\")"
     ],
     "deny": [],
     "ask": []

--- a/.claude/skills/shellspec/references/troubleshooting.md
+++ b/.claude/skills/shellspec/references/troubleshooting.md
@@ -6,7 +6,7 @@ Systematic approaches to debugging test failures and preparing scripts for testa
 
 ### Decision Tree
 
-```
+```text
 Test Fails
 ├─> Run with --xtrace (execution trace)
 ├─> Use Dump directive (inspect output)
@@ -17,22 +17,26 @@ Test Fails
 
 ### Systematic Process
 
-**Step 1: Verify Spec Syntax**
+**Step 1: Verify Spec Syntax**:
+
 ```bash
 shellspec --syntax-check spec/my_spec.sh
 ```
 
-**Step 2: Enable Trace Mode**
+**Step 2: Enable Trace Mode**:
+
 ```bash
 shellspec --xtrace spec/my_spec.sh
 ```
 
-**Step 3: Inspect Generated Code**
+**Step 3: Inspect Generated Code**:
+
 ```bash
 shellspec --translate spec/my_spec.sh
 ```
 
-**Step 4: Use Dump**
+**Step 4: Use Dump**:
+
 ```bash
 It 'fails mysteriously'
   When call my_function "input"
@@ -41,7 +45,8 @@ It 'fails mysteriously'
 End
 ```
 
-**Step 5: Run Single Test**
+**Step 5: Run Single Test**:
+
 ```bash
 shellspec spec/my_spec.sh:42
 ```
@@ -82,6 +87,7 @@ shellspec --quick
 ### Differentiating Test vs. Script Issues
 
 **Diagnostic Questions**:
+
 1. Does test fail when run alone?
 2. Does test fail with `--xtrace`?
 3. Does script work manually?
@@ -175,7 +181,8 @@ End
 
 ### Refactoring Example
 
-**Before: Untestable**
+**Before: Untestable**:
+
 ```bash
 #!/bin/bash
 # Runs immediately when sourced
@@ -183,7 +190,8 @@ curl https://api.example.com > /tmp/data.json
 /usr/local/bin/process /tmp/data.json
 ```
 
-**After: Testable**
+**After: Testable**:
+
 ```bash
 #!/bin/bash
 
@@ -212,7 +220,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 ```
 
-**Test File**
+**Test File**:
+
 ```bash
 Describe 'testable_script'
   Include testable_script.sh
@@ -230,21 +239,24 @@ End
 
 ### Source Guard Patterns
 
-**Pattern 1: Bash/Zsh**
+**Pattern 1: Bash/Zsh**:
+
 ```bash
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   main "$@"
 fi
 ```
 
-**Pattern 2: POSIX Compatible**
+**Pattern 2: POSIX Compatible**:
+
 ```bash
 if [ "$(basename -- "$0")" = "myscript.sh" ]; then
   main "$@"
 fi
 ```
 
-**Pattern 3: ShellSpec Flag**
+**Pattern 3: ShellSpec Flag**:
+
 ```bash
 ${__SOURCED__:+return}
 main "$@"
@@ -253,18 +265,22 @@ main "$@"
 ## Common Error Messages
 
 ### "Command not found"
+
 **Cause**: Unmocked external command
 **Solution**: Add Mock block
 
 ### "Function not found"
+
 **Cause**: Script not sourced
 **Solution**: Add `Include` directive
 
 ### "Permission denied"
+
 **Cause**: Script not executable
 **Solution**: `chmod +x script.sh` or use `sh script.sh`
 
 ### "Variable not preserved"
+
 **Cause**: Variable in subshell
 **Solution**: Use `%preserve` directive
 
@@ -294,6 +310,7 @@ echo "Next: shellspec --xtrace $spec_file"
 ## Best Practices Checklist
 
 ### Do's
+
 ✅ Run tests in isolation first
 ✅ Use `--xtrace` to see execution
 ✅ Use `Dump` to inspect state
@@ -303,6 +320,7 @@ echo "Next: shellspec --xtrace $spec_file"
 ✅ Clean up in `AfterEach`
 
 ### Don'ts
+
 ❌ Ignore failed tests
 ❌ Use global state
 ❌ Hard-code paths

--- a/.githook/pre-commit-copyright
+++ b/.githook/pre-commit-copyright
@@ -3,13 +3,53 @@
 
 # pre-commit hook to verify copyright notices in *.sh files
 
-VERSION="1.0.0"
-
 # Get the current date in YYYY-MM-DD format
 CURRENT_DATE=$(date +%Y-%m-%d)
 
 # Get the repository root directory
 REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Auto-detect project version using semantic version calculator
+# This computes the version based on conventional commits since last tag
+detect_project_version() {
+  local semver_script="$REPO_ROOT/bin/git.semantic-version.sh"
+
+  # Check if semantic version script exists
+  if [[ ! -f "$semver_script" ]]; then
+    # Fallback to last git tag if script not found
+    local last_tag=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+    if [[ -n "$last_tag" ]] && [[ "$last_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "$last_tag"
+    else
+      echo "1.0.0"
+    fi
+    return
+  fi
+
+  # Compute version from conventional commits (this is the source of truth)
+  # Run with default auto-detection strategy to get full computed version
+  # Strip ANSI color codes before parsing to handle colored output
+  local computed_version=$("$semver_script" 2>/dev/null | \
+    grep "Final Version:" | \
+    sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g; s/\x1B\\([A-Z]//g; s/\x0F//g' | \
+    sed -E 's/.*Final Version: *([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+  # Return computed version or fallback to git tag / 1.0.0
+  if [[ -n "$computed_version" ]] && [[ "$computed_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "$computed_version"
+  else
+    # Fallback to last git tag
+    local last_tag=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+    if [[ -n "$last_tag" ]] && [[ "$last_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "$last_tag"
+    else
+      echo "1.0.0"
+    fi
+  fi
+}
+
+# Detect the current project version
+VERSION=$(detect_project_version)
 
 # Path to the COPYRIGHT template file
 COPYRIGHT_TEMPLATE="$REPO_ROOT/COPYRIGHT"
@@ -19,6 +59,7 @@ declare -a STAGED_SH_FILES
 
 readonly cl_grey=$(tput setaf 8)
 readonly cl_gray=$cl_grey # alias to the same color
+readonly cl_cyan=$(tput setaf 6)
 readonly cl_reset=$(tput sgr0)
 
 # Check if HOOK_TEST environment variable is set (TEST mode)
@@ -148,6 +189,9 @@ if [[ ${#STAGED_SH_FILES[@]} -eq 0 ]]; then
   echo "${cl_grey}No .sh files to process (pre-commit-copyright)${cl_reset}"
   exit 0
 fi
+
+# Show detected version (helpful for debugging)
+echo "${cl_grey}Copyright hook using version: ${cl_cyan}${VERSION}${cl_reset}"
 
 # Flag to track if we should abort the commit
 ABORT_COMMIT=0

--- a/.githook/pre-commit-copyright
+++ b/.githook/pre-commit-copyright
@@ -205,6 +205,9 @@ for FILE in "${STAGED_SH_FILES[@]}"; do
   # Skip if file doesn't exist
   [[ ! -f "$FILE" ]] && continue
 
+  # Never mutate test fixtures (keeps specs stable)
+  [[ "$FILE" == spec/fixtures/* ]] && continue
+
   # Verify copyright in file
   verify_copyright "$FILE"
   copyright_status=$?

--- a/.githook/pre-commit-copyright-last-revisit
+++ b/.githook/pre-commit-copyright-last-revisit
@@ -67,6 +67,9 @@ for FILE in "${STAGED_FILES[@]}"; do
   # Skip if file doesn't exist (could happen with some git operations)
   [ ! -f "$FILE" ] && continue
 
+  # Never mutate test fixtures (keeps specs stable)
+  [[ "$FILE" == spec/fixtures/* ]] && continue
+
   # Check if file contains "## Last revisit:" line
   if ggrep -q "## Last revisit:" "$FILE"; then
     # Update the "## Last revisit:" line with current date

--- a/.scripts/_arguments.sh
+++ b/.scripts/_arguments.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155,SC2034,SC2059,SC2154
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-14
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -93,6 +93,7 @@ function parse:mapping() {
   declare -A -g index_to_keys && index_to_keys=()       # index-to-keys_definition
 
   # build parameters mapping
+  local i=0 # make $i local to avoid conflicts
   for i in "${!definitions[@]}"; do
     # TODO (olku): validate the pattern format, otherwise throw an error
     # shellcheck disable=SC2206

--- a/.scripts/_self-update.sh
+++ b/.scripts/_self-update.sh
@@ -82,7 +82,11 @@ function array:qsort() {
   local array=("$@")
   local length=${#array[@]}
 
-  if ((length <= 1)); then
+  if ((length == 0)); then
+    return
+  fi
+
+  if ((length == 1)); then
     echo "${array[@]}"
     return
   fi

--- a/.scripts/_self-update.sh
+++ b/.scripts/_self-update.sh
@@ -171,11 +171,11 @@ function self-update:version:tags() {
 
   # create sorted array of versions
   while IFS= read -r line; do
-    [ -z "$line" ] && continue # skip empty line
+    [[ -z "${line//[[:space:]]/}" ]] && continue # skip empty line
     __REPO_VERSIONS+=("$line")
   done < <(array:qsort "compare:versions" "${versions[@]}")
 
-  popd &>/dev/null || exit 1
+  popd &>/dev/null || return 1
 }
 
 # find the highest version tag in git repo that matches version expression/constraints
@@ -190,8 +190,9 @@ function self-update:version:find() {
 
   local version=""
   local last=${#__REPO_VERSIONS[@]} && ((last--))
-  for ((i = last; i >= 0; i--)); do
-    version="${__REPO_VERSIONS[$i]}"
+  local iLast # FIXME: do not reuse `i` variable, its a global variable
+  for ((iLast = last; iLast >= 0; iLast--)); do
+    version="${__REPO_VERSIONS[$iLast]}"
 
     if semver:constraints "${version}" "${constraints}"; then
       # found the highest version tag that matches version expression
@@ -230,8 +231,9 @@ function self-update:version:find:latest_stable() {
   # iterate from highest to lowest to find first stable version (no pre-release)
   local version=""
   local last=${#__REPO_VERSIONS[@]} && ((last--))
-  for ((i = last; i >= 0; i--)); do
-    version="${__REPO_VERSIONS[$i]}"
+  local iStable # FIXME: do not reuse `i` variable, its a global variable
+  for ((iStable = last; iStable >= 0; iStable--)); do
+    version="${__REPO_VERSIONS[$iStable]}"
 
     # check if version has no pre-release part (no dash after version numbers)
     if ! echo "$version" | grep -E -- "-" >/dev/null; then

--- a/.scripts/_self-update.sh
+++ b/.scripts/_self-update.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-17
+## Last revisit: 2025-12-18
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -368,7 +368,11 @@ function self-update:self:version() {
     echo "${bind_version}" # expected tag: v1.0.0
   else                     # file content
     # try to extract version from script copyright comments, expected `## Version: 1.0.0`
-    local file_version=$(grep -E "^## Version: ${__VERSION_PATTERN}$" "${script_folder}/${script_file}" | sed -E "s/^## Version: (.*)$/\1/")
+    local file_version=$(
+      grep -E "^## Version: ${__VERSION_PATTERN}$" "${script_folder}/${script_file}" \
+        | head -n 1 \
+        | sed -E "s/^## Version: (.*)$/\1/"
+    )
 
     if [ -n "${file_version}" ]; then
       echo:Version "copyright: ${cl_blue}${script_file}${cl_reset} to ${cl_yellow}${file_version}${cl_reset}" >&2

--- a/.scripts/_semver.sh
+++ b/.scripts/_semver.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-17
+## Last revisit: 2025-12-18
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -400,8 +400,11 @@ function semver:constraints:complex() {
   # `~1.0.0` - version in range >= 1.0.x, patch releases allowed
   if [[ "$molecule" =~ (~) ]]; then
     atom=${atom//\~/}
+    semver:parse "$atom" "__semver_constraints_complex_atom" || return 1
+    local atom_core="${__semver_constraints_complex_atom["version-core"]}"
+    unset __semver_constraints_complex_atom
     echo ">=$atom"
-    echo "<$(semver:increase:minor "$atom")"
+    echo "<$(semver:increase:minor "$atom_core")"
     return 0
   fi
 
@@ -409,8 +412,11 @@ function semver:constraints:complex() {
   # `^1.0.0` - version in range >= 1.x.x, minor & patch releases allowed
   if [[ "$molecule" =~ (\^) ]]; then
     atom=${atom//\^/}
+    semver:parse "$atom" "__semver_constraints_complex_atom" || return 1
+    local atom_core="${__semver_constraints_complex_atom["version-core"]}"
+    unset __semver_constraints_complex_atom
     echo ">=$atom"
-    echo "<$(semver:increase:major "$atom")"
+    echo "<$(semver:increase:major "$atom_core")"
     return 0
   fi
 
@@ -425,8 +431,9 @@ function semver:constraints:complex() {
   echo "$atom"
 }
 
-# verify that provided version matches constraints
-function semver:constraints() {
+# verify that provided version matches constraints (v1)
+# NOTE: This version does not follow npm's default prerelease exclusion behavior.
+function semver:constraints:v1() {
   local version="$1"
   local expression="$2"
 
@@ -481,6 +488,111 @@ function semver:constraints() {
   # BASH expected 0 for success, any other number for failure
   [[ "$resultOr" -eq 1 ]] && return 0 # true
   return 1                            # false
+}
+
+# verify that provided version matches constraints (v2, npm-like)
+# - prerelease versions are excluded unless the range includes a prerelease
+#   comparator with the same major.minor.patch as the candidate version.
+function semver:constraints:v2() {
+  local version="$1"
+  local expression="$2"
+
+  semver:parse "$version" "__semver_constraints_v2_version" || return 1
+  local version_pre_release="${__semver_constraints_v2_version["pre-release"]}"
+  local version_core="${__semver_constraints_v2_version["version-core"]}"
+  unset __semver_constraints_v2_version
+
+  # stable versions use legacy evaluation logic
+  if [[ -z "$version_pre_release" ]]; then
+    semver:constraints:v1 "$version" "$expression"
+    return $?
+  fi
+
+  echo:Semver "[$expression]:" >&2
+
+  # split || (or) expressions to multiple sub-expressions and process them in a loop
+  local -a expressions=() ors="" resultOr=0
+  IFS='||' read -ra expressions <<<"$expression"
+
+  for ors in "${expressions[@]}"; do
+    [ -z "$ors" ] && continue # skip empty expressions
+
+    # remove whitespace after operator, so operator stick to the right operand
+    ors=$(echo "$ors" | sed -E 's/(=|!=|>|<|>=|<=) /\1/g; s/ $//g; s/^ //g')
+    echo:Semver " |-- ($ors)" >&2
+
+    # Determine whether this comparator set explicitly allows prerelease versions
+    # for the candidate version's core (major.minor.patch).
+    local prerelease_allowed=0
+    local -a ands=() molecule=""
+    IFS=' ' read -ra ands <<<"$ors"
+
+    for molecule in "${ands[@]}"; do
+      [ -z "$molecule" ] && continue
+
+      # Normalize complex operators (~, ^) to the raw version string for prerelease detection
+      local comp="${molecule#>=}"
+      comp="${comp#<=}"
+      comp="${comp#!=}"
+      comp="${comp#>}"
+      comp="${comp#<}"
+      comp="${comp#=}"
+      comp="${comp#~}"
+      comp="${comp#^}"
+
+      # Only a comparator that contains a prerelease can allow prerelease candidates.
+      [[ "$comp" == *"-"* ]] || continue
+
+      semver:parse "$comp" "__semver_constraints_v2_comp" || continue
+      local comp_core="${__semver_constraints_v2_comp["version-core"]}"
+      unset __semver_constraints_v2_comp
+
+      if [[ "$comp_core" == "$version_core" ]]; then
+        prerelease_allowed=1
+        break
+      fi
+    done
+
+    # If this OR-set doesn't explicitly include a prerelease comparator for this
+    # major.minor.patch, it cannot match prerelease candidates.
+    [[ "$prerelease_allowed" -eq 1 ]] || continue
+
+    # Evaluate the AND-set as in v1.
+    local resultAnd=1
+    for molecule in "${ands[@]}"; do
+      [ -z "$molecule" ] && continue # skip empty expressions
+      echo:Semver " |   +-- ($molecule)" >&2
+
+      local atom=""
+      while read -r atom; do
+        echo:Semver -n " |       +-- ($version$atom)" >&2
+        if semver:constraints:simple "$version$atom"; then
+          echo:Semver " $? : TRUE" >&2
+          ((resultAnd &= 1))
+        else
+          echo:Semver " $? : FALSE" >&2
+          ((resultAnd &= 0))
+          break
+        fi
+      done < <(semver:constraints:complex "$molecule")
+
+      [[ "$resultAnd" -eq 0 ]] && break
+    done
+
+    ((resultOr |= resultAnd))
+  done
+
+  [[ "$resultOr" -eq 1 ]] && return 0 # true
+  return 1                            # false
+}
+
+# verify that provided version matches constraints (default)
+# - SEMVER_CONSTRAINTS_IMPL=v1|v2 can be used to switch behavior (v1 deprecated).
+function semver:constraints() {
+  case "${SEMVER_CONSTRAINTS_IMPL:-v2}" in
+  v1) semver:constraints:v1 "$@" ;;
+  v2 | *) semver:constraints:v2 "$@" ;;
+  esac
 }
 
 export SEMVER="$(semver:grep)"

--- a/.scripts/_semver.sh
+++ b/.scripts/_semver.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-04-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -141,6 +141,7 @@ function semver:parse() {
   local output_variable="${2:-"__semver_parse_result"}"
   local SEMVER_REGEX="$(semver:grep)"
   declare -A parsed=(["version"]="" ["version-core"]="" ["pre-release"]="" ["build"]="")
+  local i=0 # make $i local to avoid conflicts
 
   if [[ "$version" =~ $SEMVER_REGEX ]]; then
     # debug output
@@ -241,6 +242,7 @@ function semver:increase:patch() {
 function semver:compare() {
   local version1="$1"
   local version2="$2"
+  local i=0 # make $i local to avoid conflicts
 
   # quick check for equality
   if [[ "$version1" == "$version2" ]]; then return 0; fi
@@ -304,19 +306,21 @@ function semver:compare() {
     if [[ "${#parts1[@]}" -gt "${#parts2[@]}" ]]; then return 1; fi
     if [[ "${#parts1[@]}" -lt "${#parts2[@]}" ]]; then return 2; fi
 
-    # numbers are equal? but how? Only META left uncomared
+    # numbers are equal? but how? Only META left un-compared
     echo:Semver "Warning: verify versions, are is META an only difference: $version1 $version2"
     return 0
   else
     echo:Semver "Warning: No pre-release part in versions: $version1 $version2"
 
     # Build metadata MUST be ignored when determining version precedence. (Rule #10)
-    # So versions are equal during the comparisson!
+    # So versions are equal during the comparison!
     return 0
   fi
 
   # We should never reach this point!
+  # shellcheck disable=SC2059
   echo:Semver "Error: $version1 $version2" >&2
+  # shellcheck disable=SC2059
   return 3 # error
 }
 
@@ -355,6 +359,7 @@ function semver:constraints:simple() {
   # remove whitespaces during assigning to local variable
   local expression="${1//[[:space:]]/}"
   local left="" operator="" right=""
+  local i=0 # make $i local to avoid conflicts
 
   # split expression to left, operator and right parts
   if [[ "$expression" =~ ^([^<>=!]+)(!=|>=|<=|>|=|<)(.+)$ ]]; then

--- a/README.md
+++ b/README.md
@@ -381,50 +381,20 @@ Semantic Version History:
 | Commit  | Message                                                                      | Tag            | Version Change                | Diff           |
 | ------- | ---------------------------------------------------------------------------- | -------------- | ----------------------------- | -------------- |
 | cb10f67 | imported version-up.sh script                                                | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 8f1616f | preparing scripts for unit testing                                           | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 260646f | more unit tests added                                                        | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| ac06fea | github actions                                                               | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 9a948b6 | github actions, part 12                                                      | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 995e212 | github actions, part 13                                                      | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 4f4a462 | github actions, part 14                                                      | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| bc42765 | more tests added, dependencies                                               | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 0592c6f | improved functions names                                                     | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 16dc946 | improved workflow                                                            | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 0d657ba | updaed readme, roadmap added                                                 | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 89e479d | change code coverage step                                                    | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 9a997ef | Added copyright information                                                  | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| ab852e8 | cleanup                                                                      | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| e989705 | Merge pull request #1 from OleksandrKucherenko/updated-copyrights            | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| 0dd014e | introduced password input TUI                                                | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
-| bc13d6c | first version of profiler (#3)                                               | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
 | c75cdab | added several demos (#4)                                                     | -              | 0.0.1 → 0.0.1                 | +0.0.0         |
 | 32b1951 | Update README.md                                                             | v1.0.0         | 0.0.1 → 1.0.0                 | =1.0.0         |
 | 3e6d934 | small patch (#5)                                                             | v1.0.1-alpha.1 | 1.0.0 → 1.0.1-alpha.1         | =1.0.1-alpha.1 |
 | d08724e | Self update functionality (#6)                                               | -              | 1.0.1-alpha.1 → 1.0.1-alpha.1 | +0.0.0         |
-| 7da0a83 | Continue development (#7)                                                    | -              | 1.0.1-alpha.1 → 1.0.1-alpha.1 | +0.0.0         |
-| 09d8e1f | Update COPYRIGHT, spell check in comments                                    | -              | 1.0.1-alpha.1 → 1.0.1-alpha.1 | +0.0.0         |
-| ace5f94 | added: unlim comments lines support (#8)                                     | -              | 1.0.1-alpha.1 → 1.0.1-alpha.1 | +0.0.0         |
 | dffc346 | fix: kcov docker image use (#9)                                              | -              | 1.0.1-alpha.1 → 1.0.2-alpha.1 | +0.0.1         |
 | b982126 | wip: log to file and stderr                                                  | -              | 1.0.2-alpha.1 → 1.0.2-alpha.1 | +0.0.0         |
-| 54e9e0e | wip: add gawk dependency                                                     | -              | 1.0.2-alpha.1 → 1.0.2-alpha.1 | +0.0.0         |
 | 8649d55 | Document args (#10)                                                          | v1.1.0         | 1.0.2-alpha.1 → 1.1.0         | =1.1.0         |
 | 21ba265 | Update README.md                                                             | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| 7ee535d | resolved merge conflicts                                                     | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| 67a62d3 | added Ipv6 utils (#11)                                                       | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| f880300 | Updated installation link                                                    | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| f9698cc | installation short link                                                      | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| 1c0a2fa | badge added                                                                  | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| 3554bdd | badges - one more                                                            | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| 86de415 | wip: V2 version up script (#12)                                              | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
-| cc2918b | Claude/emoji printer script 011 c uo ha65 l ht rbbr2q zdw gx (#15)           | -              | 1.1.0 → 1.1.0                 | +0.0.0         |
 | b00a1d0 | fix: installation script global and local installation scenarios (#16)       | -              | 1.1.0 → 1.1.1                 | +0.0.1         |
 | 82a5c35 | wip: updated dependencies                                                    | -              | 1.1.1 → 1.1.1                 | +0.0.0         |
 | 60fcd80 | wip: code review of another PR (#18)                                         | -              | 1.1.1 → 1.1.1                 | +0.0.0         |
 | b0901ab | test: add comprehensive test coverage for version-up v2 (TDD approach) (#19) | -              | 1.1.1 → 1.1.2                 | +0.0.1         |
 | 13f8feb | feat: add git semantic version calculator script (#20)                       | -              | 1.1.2 → 1.2.0                 | +0.1.0         |
 | 2b4b34f | Fix/coverage unknown status (#21)                                            | -              | 1.2.0 → 1.2.0                 | +0.0.0         |
-| bf2da24 | Fix and optimize Codecov configuration (#22)                                 | -              | 1.2.0 → 1.2.0                 | +0.0.0         |
-| 6d6b542 | wip: small updates in documentation                                          | -              | 1.2.0 → 1.2.0                 | +0.0.0         |
 | 7cc5870 | ci: Add CI cache for Homebrew installations (#25)                            | -              | 1.2.0 → 1.2.1                 | +0.0.1         |
 | fbdee5c | feat: add mise tool support to e-bash install script (#23)                   | -              | 1.2.1 → 1.3.0                 | +0.1.0         |
 | b64d60b | feat: add trap management module with multiple handler support               | -              | 1.3.0 → 1.4.0                 | +0.1.0         |

--- a/README.md
+++ b/README.md
@@ -507,7 +507,30 @@ bin/git.files.sh 1 --tree
 
 ## Self-Update
 
-Default version script: `bin/version-up.v2.sh` (legacy v1 is kept at `legacy/bin/version-up.v1.sh`).
+**Purpose:** The self-update functionality allows any project that uses the e-bash scripts library to automatically detect source updates and update library files file-by-file. This is designed specifically for BASH scripts built on top of the e-bash library.
+
+**Main Usage Pattern:** The recommended approach is to invoke `self-update` when your script exits, ensuring the library stays current for the next execution:
+
+```bash
+# Using e-bash traps module (recommended)
+source ".scripts/_self-update.sh"
+source ".scripts/_traps.sh"
+
+function on_exit_update() {
+  self-update '^1.0.0'
+}
+trap:on on_exit_update EXIT
+
+# Or using built-in trap (simpler, but less flexible)
+trap "self-update '^1.0.0'" EXIT
+```
+
+**How It Works:**
+1. Maintains a local git repository at `~/.e-bash/` with multiple version worktrees
+2. Creates symbolic links from your project's `.scripts/` files to version-specific files
+3. Performs file-by-file updates with automatic backup creation
+4. Verifies updates using SHA1 hash comparison
+5. Supports rollback to previous versions or backup files
 
 Requirements:
 
@@ -519,14 +542,15 @@ Requirements:
   - [ ] extract archive to a version sub-folder
 - [x] rollback to previous version (or specified one)
   - [x] rollback to latest backup file (if exists)
-- [ ] partial update of the scripts, different versions of scripts from different version sub-folders
+- [x] partial update of the scripts, different versions of scripts from different version sub-folders
   - [x] developer can bind file to a specific version by calling function `self-update:version:bind`
 - [x] verify SHA1 hash of the scripts
   - [x] compute file SHA1 hash and store it in \*.sha1 file
 - [x] understand version expressions
-  - [ ] `latest` - latest stable version
-  - [ ] `*` or `next` - any highest version tag (INCLUDING: alpha, beta, rc etc)
-  - [ ] `branch:{any_branch}` or `tag:{any_tag}` - any branch name (also works for TAGs)
+  - [x] `latest` - latest stable version (no pre-release tags)
+  - [x] `*` or `next` - any highest version tag (INCLUDING: alpha, beta, rc etc)
+  - [x] `branch:{any_branch}` - update from any branch name
+  - [x] `tag:{any_tag}` - update to specific tag
   - [x] `>`, `<`, `>=`, `<=`, `~`, `!=`, `||` - comparison syntax
   - [x] `1.0.0` or `=1.0.0` - exact version
   - [x] `~1.0.0` - version in range >= 1.0.x, patch releases allowed

--- a/bin/ci.validate-envrc.sh
+++ b/bin/ci.validate-envrc.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2154
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -38,6 +38,7 @@ function parse_file() {
   mapfile -t array < <(cat "${file}")
 
   # get list of exports from direnv file
+  local i=0 # make $i local to avoid conflicts
   for ((i = 0; i < ${#array[@]}; i++)); do
     line=${array[$i]}
     if [[ $line == export\ * ]]; then

--- a/bin/npm.versions.sh
+++ b/bin/npm.versions.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-10
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -233,6 +233,7 @@ function parse_range() {
       ((end--))
       
       # Add all versions in range
+      local i=0 # make $i local to avoid conflicts
       for ((i=start; i<=end; i++)); do
         if [[ $i -ge 0 && $i -lt ${#versions[@]} ]]; then
           selected+=("$i")

--- a/bin/version-up.v2.sh
+++ b/bin/version-up.v2.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2155,SC1090,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-07-06
+## Last revisit: 2025-12-17
 ## Version: 3.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -552,6 +552,7 @@ function set_stage() {
 
 # compose version from PARTS and output it to STDOUT
 function compose() {
+    local i=0 # make $i local to avoid conflicts
 	for i in "${!PARTS[@]}"; do echo:Dbg "$i: ${PARTS[$i]}"; done
 	declare -A V=(
 		["major"]="${PARTS["major"]}"

--- a/bin/vhd.sh
+++ b/bin/vhd.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2155,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-04-26
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -238,6 +238,7 @@ function parse_range() {
             fi
 
             # Add all numbers in the range
+            local i=0 # make $i local to avoid conflicts
             for ((i = start; i <= end; i++)); do
                 indices+=("$i")
             done

--- a/demos/demo.colors.sh
+++ b/demos/demo.colors.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2024-01-02
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -12,6 +12,7 @@
 
 function report:colors() {
     local contrast=0 reset="" nl=""
+    local i=0 # make $i local to avoid conflicts
 
     reset=$(printf "\033[0m")
 

--- a/demos/demo.selfupdate.sh
+++ b/demos/demo.selfupdate.sh
@@ -54,6 +54,16 @@ demo:step "Extract latest version"
 self-update:version:get:latest
 
 # ============================================================================
+# Core functions check
+# ============================================================================
+
+demo:section "CORE FUNCTIONS CHECK"
+demo:step "1. self-update:version:find"
+
+# set -x
+self-update:version:find "1.0.0"
+
+# ============================================================================
 # VERSION RESOLUTION DEMONSTRATIONS
 # ============================================================================
 

--- a/demos/demo.selfupdate.sh
+++ b/demos/demo.selfupdate.sh
@@ -2,95 +2,399 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-10
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
+##
+## Demo: Self-Update Functionality
+##
+## This demo showcases the self-update capabilities for projects using e-bash.
+## It demonstrates version resolution, upgrades, downgrades, branch/tag pinning,
+## and rollback scenarios.
 
-export DEBUG=git,version,loader
+export DEBUG=${DEBUG:-"git,version,loader"}
 
 # shellcheck disable=SC2155 # evaluate E_BASH from project structure if it's not set
 [ -z "$E_BASH" ] && readonly E_BASH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.scripts && pwd)"
 
-# include other scripts: _colors, _logger, _commons, _dependencies, _arguments
+# include self-update module
 # shellcheck disable=SC1090 source=../.scripts/_self-update.sh
 source "$E_BASH/_self-update.sh"
 
-# full path to the script file
-#self-update:version:bind "v1.0.0" "$E_BASH/_colors.sh"
+# Helper function to print section headers
+function demo:section() {
+  echo ""
+  echo "╔════════════════════════════════════════════════════════════════════════╗"
+  echo "║ $1"
+  echo "╚════════════════════════════════════════════════════════════════════════╝"
+  echo ""
+}
 
-# relative path to the caller script file
-#self-update:version:bind "v1.0.1-alpha.1" "../.scripts/_colors.sh"
+# Helper function to print step headers
+function demo:step() {
+  echo ""
+  echo "→ $1"
+  echo ""
+}
 
-# relative path to the caller script file, project root dir
-#self-update:version:bind "v1.0.0" "00-format.sh"
+# ============================================================================
+# INITIALIZATION
+# ============================================================================
 
-# ask self-update to the version >= 1.0.0 && < 2.0.0
-#self-update "^1.0.0"
+demo:section "SELF-UPDATE DEMO: Initialization"
 
-# check for version update in range >= 1.0.0 && < 2.0.0
-#self-update "^1.0.0" "${BASH_SOURCE[0]}" "$REPO_URL"
-
-## Resolve Path
-echo "" && path:resolve "$E_BASH/_colors.sh"
-echo "" && path:resolve "../.scripts/_colors.sh"
-echo "" && path:resolve "../bin/un-link.sh"
-echo "" && path:resolve "./demo.semver.sh"
-echo "" && path:resolve "./demo.semver.sh" "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-echo "" && path:resolve "00-format.sh"
-
-## Delete repo dir, to emulate first run
-#rm -rf "${SELF_UPDATE_DIR}"
+demo:step "Initialize e-bash repository in ~/.e-bash/"
 self-update:initialize
 
-## extract first version
+demo:step "Extract first version (v1.0.0)"
 self-update:version:get:first
 
-## extract last version
+demo:step "Extract latest version"
 self-update:version:get:latest
 
-## Find Highest Tag
-echo "highest version tag: $(self-update:version:find:highest_tag)"
+# ============================================================================
+# VERSION RESOLUTION DEMONSTRATIONS
+# ============================================================================
 
-## Find tag in constraints
-echo "found version tag match: $(self-update:version:find "^1.0.0")"
+demo:section "VERSION RESOLUTION: New Notation Patterns"
 
-## Get version of the script file
-self-update:self:version "${BASH_SOURCE[0]}"
-self-update:self:version "$E_BASH/_colors.sh"
-self-update:self:version "00-format.sh"
+demo:step "1. Resolve 'latest' notation (latest stable, no pre-release)"
+echo "Expression: 'latest'"
+echo "Resolves to: $(self-update:version:resolve "latest")"
 
-## Compute file hash
-self-update:file:hash "00-format.sh"
-self-update:file:hash "$E_BASH/_colors.sh"
+demo:step "2. Resolve '*' notation (highest version, including pre-release)"
+echo "Expression: '*'"
+echo "Resolves to: $(self-update:version:resolve "*")"
 
-## Compute file hash for a specific version
-self-update:version:hash "$E_BASH/_colors.sh" "v1.0.0"
+demo:step "3. Resolve 'next' notation (same as '*')"
+echo "Expression: 'next'"
+echo "Resolves to: $(self-update:version:resolve "next")"
 
-## Assign/Bind file version
-echo "bind 1.0.0"
-self-update:version:bind "v1.0.0" "$E_BASH/_colors.sh"
+demo:step "4. Resolve 'branch:master' notation"
+echo "Expression: 'branch:master'"
+echo "Resolves to: $(self-update:version:resolve "branch:master")"
 
-echo "bind 1.0.1-alpha.1"
-self-update:version:bind "v1.0.1-alpha.1" "$E_BASH/_colors.sh"
+demo:step "5. Resolve 'tag:v1.0.0' notation"
+echo "Expression: 'tag:v1.0.0'"
+echo "Resolves to: $(self-update:version:resolve "tag:v1.0.0")"
 
-## Rollback file changes
-echo "rollback to 1.0.0"
-self-update:rollback:version "v1.0.0" "$E_BASH/_colors.sh"
-# expected: _colors.sh -> ~/.e-bash/.versions/v1.0.0/.scripts/_colors.sh
-ls -la "$E_BASH" | grep _colors
+demo:step "6. Resolve semver constraint '^1.0.0' (minor/patch allowed)"
+echo "Expression: '^1.0.0'"
+echo "Resolves to: $(self-update:version:resolve "^1.0.0")"
 
-## Unlinking
-echo "unlink"
-self-update:unlink "$E_BASH/_colors.sh"
-ls -la "$E_BASH" | grep _colors
+demo:step "7. Resolve semver constraint '~1.0.0' (patch only)"
+echo "Expression: '~1.0.0'"
+echo "Resolves to: $(self-update:version:resolve "~1.0.0")"
 
-echo "rollback to original"
-# while exists backup files run rollback
-while find "${E_BASH}" -name "_colors.sh.~*~" | grep . >/dev/null; do
-  self-update:rollback:backup "${E_BASH}/_colors.sh"
+# ============================================================================
+# VERSION INFORMATION
+# ============================================================================
+
+demo:section "VERSION INFORMATION: Query Available Versions"
+
+demo:step "Find highest version tag (including pre-release)"
+echo "Highest tag: $(self-update:version:find:highest_tag)"
+
+demo:step "Find latest stable version tag (no pre-release)"
+echo "Latest stable: $(self-update:version:find:latest_stable)"
+
+demo:step "Find version matching constraint '^1.0.0'"
+echo "Match for '^1.0.0': $(self-update:version:find "^1.0.0")"
+
+demo:step "List all available versions"
+self-update:version:tags
+echo "Available versions:"
+for version in "${__REPO_VERSIONS[@]}"; do
+  tag="${__REPO_MAPPING[$version]}"
+  echo "  - $tag ($version)"
 done
 
-## Unlinking, error state
-# expected: `e-bash unlink: _colors.sh - NOT A LINK`
+# ============================================================================
+# FILE VERSION BINDING & MANAGEMENT
+# ============================================================================
+
+demo:section "FILE VERSION BINDING: Link Files to Specific Versions"
+
+TEST_FILE="$E_BASH/_colors.sh"
+
+demo:step "Get current version of _colors.sh"
+current_version=$(self-update:self:version "$TEST_FILE")
+echo "Current version: $current_version"
+
+demo:step "Compute file hash"
+file_hash=$(self-update:file:hash "$TEST_FILE")
+echo "SHA1 hash: $file_hash"
+
+demo:step "Bind _colors.sh to v1.0.0"
+self-update:version:bind "v1.0.0" "$TEST_FILE"
+ls -la "$E_BASH" | grep _colors
+
+demo:step "Compute hash of versioned file (v1.0.0)"
+version_hash=$(self-update:version:hash "$TEST_FILE" "v1.0.0")
+echo "Version v1.0.0 hash: $version_hash"
+
+# ============================================================================
+# UPGRADE SCENARIOS
+# ============================================================================
+
+demo:section "UPGRADE SCENARIOS: Different Upgrade Patterns"
+
+demo:step "Scenario 1: Upgrade to latest stable version"
+echo "Command: self-update \"latest\" \"$TEST_FILE\""
+echo "This will upgrade to the highest stable version (no alpha/beta/rc)"
+# Uncomment to execute:
+# self-update "latest" "$TEST_FILE"
+
+demo:step "Scenario 2: Upgrade to cutting edge (including pre-release)"
+echo "Command: self-update \"*\" \"$TEST_FILE\""
+echo "This will upgrade to the absolute highest version, including pre-releases"
+# Uncomment to execute:
+# self-update "*" "$TEST_FILE"
+
+demo:step "Scenario 3: Upgrade within minor version range"
+echo "Command: self-update \"^1.0.0\" \"$TEST_FILE\""
+echo "This allows minor and patch updates: >= 1.0.0 && < 2.0.0"
+# Uncomment to execute:
+# self-update "^1.0.0" "$TEST_FILE"
+
+demo:step "Scenario 4: Upgrade within patch version range"
+echo "Command: self-update \"~1.0.0\" \"$TEST_FILE\""
+echo "This allows only patch updates: >= 1.0.0 && < 1.1.0"
+# Uncomment to execute:
+# self-update "~1.0.0" "$TEST_FILE"
+
+# ============================================================================
+# DOWNGRADE SCENARIOS
+# ============================================================================
+
+demo:section "DOWNGRADE SCENARIOS: Reverting to Older Versions"
+
+demo:step "Scenario 1: Downgrade to specific tag"
+echo "Command: self-update \"tag:v1.0.0\" \"$TEST_FILE\""
+echo "This pins the file to a specific tag version"
+# Uncomment to execute:
+# self-update "tag:v1.0.0" "$TEST_FILE"
+
+demo:step "Scenario 2: Downgrade using exact version"
+echo "Command: self-update \"1.0.0\" \"$TEST_FILE\""
+echo "This downgrades to exactly version 1.0.0"
+# Uncomment to execute:
+# self-update "1.0.0" "$TEST_FILE"
+
+demo:step "Scenario 3: Rollback to previous version"
+echo "Command: self-update:rollback:version \"v1.0.0\" \"$TEST_FILE\""
+echo "This manually rolls back to a specific version"
+self-update:rollback:version "v1.0.0" "$TEST_FILE"
+ls -la "$E_BASH" | grep _colors
+
+# ============================================================================
+# BRANCH/TAG PINNING SCENARIOS
+# ============================================================================
+
+demo:section "BRANCH/TAG PINNING: Development & Testing"
+
+demo:step "Scenario 1: Pin to master branch (bleeding edge)"
+echo "Command: self-update \"branch:master\" \"$TEST_FILE\""
+echo "This tracks the master branch HEAD (latest development)"
+# Uncomment to execute:
+# self-update "branch:master" "$TEST_FILE"
+
+demo:step "Scenario 2: Pin to development branch"
+echo "Command: self-update \"branch:develop\" \"$TEST_FILE\""
+echo "This tracks a development branch (if it exists)"
+# Uncomment to execute:
+# self-update "branch:develop" "$TEST_FILE"
+
+demo:step "Scenario 3: Pin to specific pre-release tag"
+echo "Command: self-update \"tag:v1.0.1-alpha.1\" \"$TEST_FILE\""
+echo "This pins to a specific pre-release version for testing"
+# Uncomment to execute:
+# self-update "tag:v1.0.1-alpha.1" "$TEST_FILE"
+
+# ============================================================================
+# ROLLBACK & RECOVERY
+# ============================================================================
+
+demo:section "ROLLBACK & RECOVERY: Undo Changes"
+
+demo:step "Scenario 1: Unlink file (convert symlink to regular file)"
+echo "Command: self-update:unlink \"$TEST_FILE\""
+self-update:unlink "$TEST_FILE"
+ls -la "$E_BASH" | grep _colors
+
+demo:step "Scenario 2: Rollback from backup files"
+echo "Backup files created: .~N~ format"
+find "${E_BASH}" -name "_colors.sh.~*~" | head -3
+
+echo ""
+echo "Command: self-update:rollback:backup \"$TEST_FILE\""
+echo "This restores from the latest numbered backup"
+
+# Restore from backup if backups exist
+while find "${E_BASH}" -name "_colors.sh.~*~" | grep . >/dev/null; do
+  self-update:rollback:backup "${E_BASH}/_colors.sh"
+  break # Just do one for demo
+done
+
+demo:step "Scenario 3: Try to unlink non-linked file (error handling)"
+# This should show: "e-bash unlink: _colors.sh - NOT A LINK"
 self-update:unlink "$E_BASH/_colors.sh"
+
+# ============================================================================
+# REAL-WORLD USAGE PATTERNS
+# ============================================================================
+
+demo:section "REAL-WORLD USAGE PATTERNS"
+
+demo:step "Pattern 1: Auto-update on script exit (Recommended)"
+cat << 'EOF'
+#!/usr/bin/env bash
+source ".scripts/_self-update.sh"
+source ".scripts/_traps.sh"
+
+# Update to latest compatible version when script exits
+function on_exit_update() {
+  self-update '^1.0.0'
+}
+trap:on on_exit_update EXIT
+
+# Your script logic here...
+echo "Script running with e-bash v$(self-update:self:version)"
+EOF
+
+demo:step "Pattern 2: Conditional update based on environment"
+cat << 'EOF'
+#!/usr/bin/env bash
+source ".scripts/_self-update.sh"
+source ".scripts/_traps.sh"
+
+function on_exit_update() {
+  if [[ "${CI}" == "true" ]]; then
+    # In CI: use stable versions only
+    self-update 'latest'
+  else
+    # Local development: allow pre-releases
+    self-update '*'
+  fi
+}
+trap:on on_exit_update EXIT
+EOF
+
+demo:step "Pattern 3: Pin to specific version in production"
+cat << 'EOF'
+#!/usr/bin/env bash
+source ".scripts/_self-update.sh"
+source ".scripts/_traps.sh"
+
+function on_exit_update() {
+  if [[ "${ENVIRONMENT}" == "production" ]]; then
+    # Production: pin to tested version
+    self-update "tag:v1.0.0"
+  else
+    # Other environments: use latest stable
+    self-update "latest"
+  fi
+}
+trap:on on_exit_update EXIT
+EOF
+
+demo:step "Pattern 4: Update specific files independently"
+cat << 'EOF'
+#!/usr/bin/env bash
+source ".scripts/_self-update.sh"
+
+# Update core files to stable
+self-update "latest" ".scripts/_logger.sh"
+self-update "latest" ".scripts/_commons.sh"
+
+# Keep experimental features on bleeding edge
+self-update "*" ".scripts/_experimental.sh"
+EOF
+
+demo:step "Pattern 5: Version constraints for compatibility"
+cat << 'EOF'
+#!/usr/bin/env bash
+source ".scripts/_self-update.sh"
+
+# Stay on 1.x.x for compatibility with legacy systems
+self-update "^1.0.0"
+
+# Or: allow only critical patches
+self-update "~1.0.0"
+
+# Or: specific range
+self-update ">1.0.0 <=1.5.0"
+EOF
+
+# ============================================================================
+# PATH RESOLUTION TESTS
+# ============================================================================
+
+demo:section "PATH RESOLUTION: Testing Different Path Formats"
+
+demo:step "Resolve absolute path"
+path:resolve "$E_BASH/_colors.sh"
+
+demo:step "Resolve relative path from current directory"
+path:resolve "../.scripts/_colors.sh"
+
+demo:step "Resolve path relative to script directory"
+path:resolve "./demo.semver.sh"
+
+demo:step "Resolve with explicit working directory"
+path:resolve "./demo.semver.sh" "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+demo:section "DEMO COMPLETE: Summary"
+
+cat << 'EOF'
+✅ Demonstrated Features:
+
+1. Version Resolution:
+   - latest, *, next notations
+   - branch:{name} and tag:{name} patterns
+   - Semver constraints (^, ~, ranges)
+
+2. Upgrade Scenarios:
+   - Latest stable vs cutting edge
+   - Constrained version ranges
+   - Incremental updates
+
+3. Downgrade Scenarios:
+   - Specific version pinning
+   - Tag-based downgrades
+   - Manual rollback
+
+4. Branch/Tag Pinning:
+   - Development branch tracking
+   - Pre-release testing
+   - Production version pinning
+
+5. Rollback & Recovery:
+   - Backup file management
+   - Symlink unlinking
+   - Version restoration
+
+6. Real-World Patterns:
+   - Auto-update on exit
+   - Environment-based strategies
+   - Independent file versioning
+
+For more information:
+  - README.md: Overview and quick start
+  - .scripts/_self-update.sh: Implementation details
+  - spec/self_update_spec.sh: Unit tests and examples
+
+Next steps:
+  - Uncomment the example commands above to test live updates
+  - Integrate self-update into your own scripts
+  - Experiment with different version expressions
+EOF
+
+echo ""
+echo "Demo finished successfully!"
+echo ""

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "_comment": "DEPRECATED: This file has been moved to .github/scripts/junit/package.json. Please delete this file.",
-  "name": "DEPRECATED",
-  "private": true
-}

--- a/spec/arguments_spec.sh
+++ b/spec/arguments_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/commons_spec.sh
+++ b/spec/commons_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016,SC2288,SC2155,SC2329
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-14
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/dependencies_spec.sh
+++ b/spec/dependencies_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-14
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/dryrun_spec.sh
+++ b/spec/dryrun_spec.sh
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2317,SC2016,SC2288
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
@@ -60,9 +60,29 @@ Mock echo:Rollback
   echo "$@"
 End
 
+Mock echo:Undo
+  # Output to stdout for undo messages
+  echo "$@"
+End
+
+Mock printf:Undo
+  # Redirect to stderr to match actual behavior
+  printf "$@" >&2
+End
+
+Mock echo:Udry
+  # Output to stdout for undo dry-run messages with prefix
+  echo "(dry) $*"
+End
+
+Mock printf:Udry
+  # Redirect to stderr to match actual behavior
+  printf "$@" >&2
+End
+
 Mock log:Output
-  # Pass through the output as expected by the tests
-  cat
+  # Redirect to stderr to avoid duplicate output on stdout
+  cat >&2
 End
 
 Mock echo:Loader

--- a/spec/dryrun_spec.sh
+++ b/spec/dryrun_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016,SC2288
 

--- a/spec/fixtures/no-version.sh
+++ b/spec/fixtures/no-version.sh
@@ -1,9 +1,3 @@
 #!/usr/bin/env bash
 
-## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.10.0
-## License: MIT
-## Source: https://github.com/OleksandrKucherenko/e-bash
-
 echo "test"

--- a/spec/fixtures/no-version.sh
+++ b/spec/fixtures/no-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-18
+## Version: 1.10.0
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+echo "test"

--- a/spec/fixtures/versioned-script.sh
+++ b/spec/fixtures/versioned-script.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 
-## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.10.0
-## License: MIT
-## Source: https://github.com/OleksandrKucherenko/e-bash
-
 ## Version: 1.2.3
 echo "test"

--- a/spec/fixtures/versioned-script.sh
+++ b/spec/fixtures/versioned-script.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-18
+## Version: 1.10.0
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Version: 1.2.3
+echo "test"

--- a/spec/git_semantic_version_spec.sh
+++ b/spec/git_semantic_version_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2155,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/installation_spec.sh
+++ b/spec/installation_spec.sh
@@ -188,8 +188,14 @@ Describe 'bin/install.e-bash.sh /'
 
   # Define a helper function to strip ANSI escape sequences
   # $1 = stdout, $2 = stderr, $3 = exit status of the command
-  no_colors_error() { echo -n "$2" | sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g; s/\x1B\\([A-Z]//g; s/\x0F//g' | tr -s ' '; }
-  no_colors_output() { echo -n "$1" | sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g; s/\x1B\\([A-Z]//g; s/\x0F//g' | tr -s ' '; }
+  no_colors_error() { 
+    # Use printf to create the escape sequences for better portability
+    echo -n "$2" | sed -E "s/$(printf '\033')\[[0-9;]*[A-Za-z]//g; s/$(printf '\033')\([A-Z]//g; s/$(printf '\017')//g" | tr -s ' '
+  }
+  no_colors_output() { 
+    # Use printf to create the escape sequences for better portability
+    echo -n "$1" | sed -E "s/$(printf '\033')\[[0-9;]*[A-Za-z]//g; s/$(printf '\033')\([A-Z]//g; s/$(printf '\017')//g" | tr -s ' '
+  }
 
   Describe 'Check Prerequisites /'
     Before 'temp_repo; cp_install'

--- a/spec/installation_spec.sh
+++ b/spec/installation_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-12
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/logger_spec.sh
+++ b/spec/logger_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/self_update_spec.sh
+++ b/spec/self_update_spec.sh
@@ -1,0 +1,492 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2154,SC2155
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-17
+## Version: 1.0.0
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+
+Describe 'Self-Update Module'
+  # Note: We include the script which defines readonly variables
+  # Do not try to override them in setup
+  Include .scripts/_self-update.sh
+
+  setup() {
+    # Mock all logger functions to avoid errors
+    echo:Version() { :; }  # Silent mock
+    echo:Git() { :; }      # Silent mock
+    echo:Regex() { :; }    # Silent mock
+    echo:Loader() { :; }   # Silent mock
+    echo:Simple() { :; }   # Silent mock
+    printf:Version() { :; }
+    printf:Git() { :; }
+    printf:Regex() { :; }
+    printf:Simple() { :; }
+  }
+
+  cleanup() {
+    # Clean up test artifacts
+    # Note: cannot unset readonly variables, just clean up our test data
+    __REPO_VERSIONS=()
+    declare -g -A __REPO_MAPPING=()
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  Describe 'compare:versions'
+    It 'compares two versions correctly (1.0.0 < 2.0.0)'
+      When call compare:versions "1.0.0" "2.0.0"
+      The status should be success
+    End
+
+    It 'compares two versions correctly (2.0.0 > 1.0.0)'
+      When call compare:versions "2.0.0" "1.0.0"
+      The status should be failure
+    End
+
+    It 'handles pre-release versions (1.0.0-alpha < 1.0.0)'
+      When call compare:versions "1.0.0-alpha" "1.0.0"
+      The status should be success
+    End
+
+    It 'handles equal versions (1.0.0 = 1.0.0)'
+      When call compare:versions "1.0.0" "1.0.0"
+      The status should be failure
+    End
+  End
+
+  Describe 'array:qsort'
+    It 'sorts an empty array'
+      When call array:qsort "compare:versions"
+      The output should equal ""
+    End
+
+    It 'sorts a single element array'
+      When call array:qsort "compare:versions" "1.0.0"
+      The output should equal "1.0.0"
+    End
+
+    It 'sorts multiple versions in ascending order'
+      When call array:qsort "compare:versions" "2.0.0" "1.0.0" "1.5.0"
+      The line 1 should equal "1.0.0"
+      The line 2 should equal "1.5.0"
+      The line 3 should equal "2.0.0"
+    End
+
+    It 'sorts versions with pre-release tags correctly'
+      When call array:qsort "compare:versions" "1.0.0" "1.0.0-beta" "1.0.0-alpha" "2.0.0"
+      The line 1 should equal "1.0.0-alpha"
+      The line 2 should equal "1.0.0-beta"
+      The line 3 should equal "1.0.0"
+      The line 4 should equal "2.0.0"
+    End
+  End
+
+  Describe 'self-update:version:tags'
+    setup_mock_repo() {
+      # Mock git tag command to return test tags
+      __REPO_VERSIONS=()
+      __REPO_MAPPING=()
+
+      # Simulate having these tags available
+      # We'll mock this by directly setting the arrays
+      __REPO_VERSIONS=("1.0.0" "1.0.1" "1.1.0" "2.0.0")
+      __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1"]="v1.0.1"
+        ["1.1.0"]="v1.1.0"
+        ["2.0.0"]="v2.0.0"
+      )
+    }
+
+    BeforeEach 'setup_mock_repo'
+
+    It 'populates __REPO_VERSIONS array'
+      The variable __REPO_VERSIONS[@] should not be blank
+      The value "${#__REPO_VERSIONS[@]}" should equal 4
+    End
+
+    It 'populates __REPO_MAPPING associative array'
+      The variable __REPO_MAPPING[@] should not be blank
+      The value "${__REPO_MAPPING[1.0.0]}" should equal "v1.0.0"
+    End
+
+    It 'sorts versions in ascending order'
+      The value "${__REPO_VERSIONS[0]}" should equal "1.0.0"
+      The value "${__REPO_VERSIONS[3]}" should equal "2.0.0"
+    End
+  End
+
+  Describe 'self-update:version:find:highest_tag'
+    setup_versions() {
+      __REPO_VERSIONS=("1.0.0" "1.0.1-alpha" "1.1.0" "2.0.0-beta" "2.0.0")
+      declare -g -A __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1-alpha"]="v1.0.1-alpha"
+        ["1.1.0"]="v1.1.0"
+        ["2.0.0-beta"]="v2.0.0-beta"
+        ["2.0.0"]="v2.0.0"
+      )
+    }
+
+    BeforeEach 'setup_versions'
+
+    It 'returns the highest version tag'
+      When call self-update:version:find:highest_tag
+      The output should equal "v2.0.0"
+    End
+
+    It 'includes pre-release versions in consideration'
+      # Remove the stable 2.0.0, highest should be 2.0.0-beta
+      unset '__REPO_VERSIONS[4]'
+      __REPO_VERSIONS=("${__REPO_VERSIONS[@]}")  # re-index array
+
+      When call self-update:version:find:highest_tag
+      The output should equal "v2.0.0-beta"
+    End
+  End
+
+  Describe 'self-update:version:find:latest_stable'
+    setup_versions_with_prerelease() {
+      __REPO_VERSIONS=("1.0.0" "1.0.1-alpha" "1.1.0" "2.0.0-beta" "2.0.0-rc.1")
+      declare -g -A __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1-alpha"]="v1.0.1-alpha"
+        ["1.1.0"]="v1.1.0"
+        ["2.0.0-beta"]="v2.0.0-beta"
+        ["2.0.0-rc.1"]="v2.0.0-rc.1"
+      )
+    }
+
+    BeforeEach 'setup_versions_with_prerelease'
+
+    It 'returns the latest stable version (no pre-release)'
+      When call self-update:version:find:latest_stable
+      The output should equal "v1.1.0"
+    End
+
+    It 'skips pre-release versions (alpha, beta, rc)'
+      # Verify it doesn't return 2.0.0-beta or 2.0.0-rc.1
+      When call self-update:version:find:latest_stable
+      The output should not equal "v2.0.0-beta"
+      The output should not equal "v2.0.0-rc.1"
+    End
+  End
+
+  Describe 'self-update:version:find:latest_stable with stable highest'
+    setup_stable_versions() {
+      __REPO_VERSIONS=("1.0.0" "1.0.1-alpha" "1.1.0" "2.0.0")
+      declare -g -A __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1-alpha"]="v1.0.1-alpha"
+        ["1.1.0"]="v1.1.0"
+        ["2.0.0"]="v2.0.0"
+      )
+    }
+
+    BeforeEach 'setup_stable_versions'
+
+    It 'returns the highest stable version when it is the highest overall'
+      When call self-update:version:find:latest_stable
+      The output should equal "v2.0.0"
+    End
+  End
+
+  Describe 'self-update:version:find'
+    setup_find_versions() {
+      __REPO_VERSIONS=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "2.0.0")
+      declare -g -A __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1"]="v1.0.1"
+        ["1.1.0"]="v1.1.0"
+        ["1.2.0"]="v1.2.0"
+        ["2.0.0"]="v2.0.0"
+      )
+    }
+
+    BeforeEach 'setup_find_versions'
+
+    It 'finds exact version match (1.0.0)'
+      When call self-update:version:find "1.0.0"
+      The output should equal "v1.0.0"
+    End
+
+    It 'finds highest version matching caret constraint (^1.0.0)'
+      When call self-update:version:find "^1.0.0"
+      The output should equal "v1.2.0"
+    End
+
+    It 'finds highest version matching tilde constraint (~1.0.0)'
+      When call self-update:version:find "~1.0.0"
+      The output should equal "v1.0.1"
+    End
+
+    It 'finds version in range (>1.0.0 <=1.1.0)'
+      When call self-update:version:find ">1.0.0 <=1.1.0"
+      The output should equal "v1.1.0"
+    End
+  End
+
+  Describe 'self-update version expression handling'
+    setup_update_test() {
+      # Mock necessary functions to avoid actual git operations
+      self-update:initialize() { :; }
+      self-update:version:get:latest() { :; }
+      self-update:version:has() { return 0; }
+      self-update:version:get() { :; }
+      self-update:self:version() { echo "v1.0.0"; }
+      self-update:version:bind() { :; }
+      self-update:file:hash() { echo "mock-hash"; }
+      self-update:version:hash() { echo "different-hash"; }
+
+      # Setup version data
+      __REPO_VERSIONS=("1.0.0" "1.0.1-alpha" "1.1.0" "2.0.0-beta" "2.0.0")
+      declare -g -A __REPO_MAPPING=(
+        ["1.0.0"]="v1.0.0"
+        ["1.0.1-alpha"]="v1.0.1-alpha"
+        ["1.1.0"]="v1.1.0"
+        ["2.0.0-beta"]="v2.0.0-beta"
+        ["2.0.0"]="v2.0.0"
+      )
+    }
+
+    BeforeEach 'setup_update_test'
+
+    Describe 'latest notation'
+      It 'resolves "latest" to latest stable version'
+        # We need to verify the version selected, mock the bind to capture it
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v2.0.0"
+        }
+
+        When call self-update "latest" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v2.0.0"
+      End
+    End
+
+    Describe '* (star) notation'
+      It 'resolves "*" to highest version (including pre-release)'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v2.0.0"
+        }
+
+        When call self-update "*" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v2.0.0"
+      End
+
+      It 'resolves "next" to highest version (including pre-release)'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v2.0.0"
+        }
+
+        When call self-update "next" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v2.0.0"
+      End
+    End
+
+    Describe 'branch:* notation'
+      It 'resolves "branch:master" to "master"'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "master"
+        }
+
+        When call self-update "branch:master" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: master"
+      End
+
+      It 'resolves "branch:develop" to "develop"'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "develop"
+        }
+
+        When call self-update "branch:develop" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: develop"
+      End
+    End
+
+    Describe 'tag:* notation'
+      It 'resolves "tag:v1.0.0" to "v1.0.0"'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v1.0.0"
+        }
+
+        When call self-update "tag:v1.0.0" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v1.0.0"
+      End
+
+      It 'resolves "tag:v2.0.0-beta" to "v2.0.0-beta"'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v2.0.0-beta"
+        }
+
+        When call self-update "tag:v2.0.0-beta" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v2.0.0-beta"
+      End
+    End
+
+    Describe 'semver constraint expressions'
+      It 'resolves "^1.0.0" using semver constraints'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          test "$1" = "v1.1.0"
+        }
+
+        When call self-update "^1.0.0" "/tmp/test-script.sh"
+        The status should be success
+        The stderr should include "binding to: v1.1.0"
+      End
+
+      It 'resolves "~1.0.0" using semver constraints'
+        self-update:version:bind() {
+          echo "binding to: $1" >&2
+          # Should match highest patch version in 1.0.x
+          [[ "$1" == "v1.0.0" || "$1" == "v1.0.1" ]]
+        }
+
+        When call self-update "~1.0.0" "/tmp/test-script.sh"
+        The status should be success
+      End
+    End
+  End
+
+  Describe 'path:resolve'
+    setup_path_test() {
+      # Create temporary directory structure for testing
+      TEMP_DIR=$(mktemp -d)
+      mkdir -p "$TEMP_DIR/subdir"
+      touch "$TEMP_DIR/test-file.sh"
+      touch "$TEMP_DIR/subdir/nested-file.sh"
+    }
+
+    cleanup_path_test() {
+      rm -rf "$TEMP_DIR"
+    }
+
+    BeforeEach 'setup_path_test'
+    AfterEach 'cleanup_path_test'
+
+    It 'resolves absolute path'
+      When call path:resolve "$TEMP_DIR/test-file.sh" "$TEMP_DIR"
+      The output should equal "$TEMP_DIR/test-file.sh"
+      The status should be success
+    End
+
+    It 'resolves relative path from working directory'
+      cd "$TEMP_DIR"
+      When call path:resolve "test-file.sh" "$TEMP_DIR"
+      The output should equal "$TEMP_DIR/test-file.sh"
+      The status should be success
+    End
+
+    It 'resolves nested file path'
+      When call path:resolve "$TEMP_DIR/subdir/nested-file.sh" "$TEMP_DIR"
+      The output should equal "$TEMP_DIR/subdir/nested-file.sh"
+      The status should be success
+    End
+
+    It 'returns error for non-existent file'
+      When call path:resolve "$TEMP_DIR/non-existent.sh" "$TEMP_DIR"
+      The status should be failure
+    End
+  End
+
+  Describe 'self-update:self:version'
+    setup_version_test() {
+      TEMP_DIR=$(mktemp -d)
+
+      # Create test script with version in copyright
+      cat > "$TEMP_DIR/versioned-script.sh" << 'EOF'
+#!/usr/bin/env bash
+## Version: 1.2.3
+echo "test"
+EOF
+
+      # Create test script without version
+      cat > "$TEMP_DIR/no-version.sh" << 'EOF'
+#!/usr/bin/env bash
+echo "test"
+EOF
+
+      chmod +x "$TEMP_DIR"/*.sh
+    }
+
+    cleanup_version_test() {
+      rm -rf "$TEMP_DIR"
+    }
+
+    BeforeEach 'setup_version_test'
+    AfterEach 'cleanup_version_test'
+
+    It 'extracts version from script copyright comments'
+      When call self-update:self:version "$TEMP_DIR/versioned-script.sh"
+      The output should equal "v1.2.3"
+    End
+
+    It 'returns default version for scripts without version comments'
+      When call self-update:self:version "$TEMP_DIR/no-version.sh"
+      The output should equal "v1.0.0"
+    End
+  End
+
+  Describe 'self-update:file:hash'
+    setup_hash_test() {
+      TEMP_DIR=$(mktemp -d)
+      echo "test content" > "$TEMP_DIR/test-file.sh"
+    }
+
+    cleanup_hash_test() {
+      rm -rf "$TEMP_DIR"
+    }
+
+    BeforeEach 'setup_hash_test'
+    AfterEach 'cleanup_hash_test'
+
+    It 'calculates SHA1 hash of file'
+      When call self-update:file:hash "$TEMP_DIR/test-file.sh"
+      The output should match pattern '^[a-f0-9]{40}$'
+      The status should be success
+    End
+
+    It 'creates .sha1 cache file'
+      self-update:file:hash "$TEMP_DIR/test-file.sh" >/dev/null
+      The path "$TEMP_DIR/test-file.sh.sha1" should be file
+    End
+
+    It 'uses cached hash on subsequent calls'
+      # First call creates cache
+      hash1=$(self-update:file:hash "$TEMP_DIR/test-file.sh")
+      # Second call should use cache
+      hash2=$(self-update:file:hash "$TEMP_DIR/test-file.sh")
+
+      The value "$hash1" should equal "$hash2"
+    End
+
+    It 'detects file changes and updates hash'
+      hash1=$(self-update:file:hash "$TEMP_DIR/test-file.sh")
+
+      # Modify file
+      echo "modified content" > "$TEMP_DIR/test-file.sh"
+
+      hash2=$(self-update:file:hash "$TEMP_DIR/test-file.sh")
+
+      The value "$hash1" should not equal "$hash2"
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/traps_nested_spec.sh
+++ b/spec/traps_nested_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/traps_spec.sh
+++ b/spec/traps_spec.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 # shellcheck disable=SC2317,SC2016,SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash

--- a/spec/version-up_spec.sh
+++ b/spec/version-up_spec.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# shell: sh altsh=shellspec
+# shell: bash altsh=shellspec
 # shellcheck shell=bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-13
+## Last revisit: 2025-12-17
 ## Version: 1.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enhances the self-update functionality with new version notation patterns and improves the dryrun module's logging clarity.

**Key Changes:**

- **New version expressions in `_self-update.sh`:**
  - `latest` - resolves to the highest stable version (no pre-release)
  - `*` or `next` - resolves to the highest version including pre-releases
  - `branch:{name}` - pins to a specific branch
  - `tag:{name}` - pins to a specific tag

- **New `self-update:version:resolve()` function** that handles all version notation patterns in a single entry point

- **New `self-update:version:find:latest_stable()` function** that finds the highest version without pre-release tags (alpha, beta, rc)

- **Fixed edge case in `array:qsort()`** for empty arrays (now returns early instead of outputting empty string)

- **Refactored `_dryrun.sh`:**
  - `dryrun:exec()` now outputs command results to stdout (previously only logged to stderr)
  - Renamed logger tags from `Rollback` to `Undo` and added new `Udry` logger for dry-run undo messages
  - Better separation of "on undo" (dry preview) vs "undoing" (actual execution) states

- **Comprehensive test suite** added for self-update module (`spec/self_update_spec.sh`)

- **Expanded demo script** with thorough examples of all version expressions and usage patterns

- **Documentation updates** in README.md explaining the self-update system's purpose, usage patterns, and how it works

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor test fix needed for complete test coverage
- The code changes are well-structured with comprehensive test coverage for the new self-update functionality. The only issue found is a missing color variable mock in the dryrun test file which could cause test failures. The core functionality is solid and the new version notation patterns are well-implemented.
- spec/dryrun_spec.sh - missing cl_purple and cl_yellow in color variable mocks

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .scripts/_dryrun.sh | Refactored dryrun:exec() to output to stdout, renamed logger tags from Rollback to Undo/Udry for better clarity, added new 'udry' logger for dry-run undo mode |
| .scripts/_self-update.sh | Added new version notations (latest, *, next, branch:*, tag:*), new self-update:version:resolve() function, improved documentation in header comments, fixed array:qsort edge case for empty arrays |
| README.md | Updated Self-Update section with comprehensive documentation on purpose, usage patterns, and how the feature works |
| demos/demo.selfupdate.sh | Completely rewritten demo script with comprehensive sections demonstrating version resolution, upgrade/downgrade scenarios, branch/tag pinning, rollback, and real-world usage patterns |
| spec/dryrun_spec.sh | Added mocks for echo:Undo, printf:Undo, echo:Udry, printf:Udry to support renamed logger tags. Missing cl_purple and cl_yellow in BeforeAll color mock. |
| spec/self_update_spec.sh | New comprehensive test suite covering version comparison, qsort, version resolution (latest, *, next, branch:*, tag:*), path resolution, file hashing, and self-update functionality |
| .claude/settings.local.json | Added new Bash permission for array:qsort command, fixed missing newline at end of file |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Script as User Script
    participant SU as _self-update.sh
    participant VR as version:resolve()
    participant Git as ~/.e-bash/ (git repo)
    
    Script->>SU: self-update("latest")
    SU->>SU: initialize()
    SU->>Git: fetch --all
    SU->>VR: resolve("latest")
    
    alt latest notation
        VR->>SU: find:latest_stable()
        SU-->>VR: v2.0.0 (no pre-release)
    else * or next notation
        VR->>SU: find:highest_tag()
        SU-->>VR: v2.1.0-alpha (includes pre-release)
    else branch:master notation
        VR-->>SU: "master"
    else tag:v1.0.0 notation
        VR-->>SU: "v1.0.0"
    else semver constraint (^1.0.0)
        VR->>SU: version:find("^1.0.0")
        SU-->>VR: v1.2.0
    end
    
    VR-->>SU: resolved_version
    SU->>SU: version:has(resolved_version)
    
    alt version not available locally
        SU->>Git: worktree add (resolved_version)
    end
    
    SU->>SU: version:bind(resolved_version, file)
    SU->>Script: symlink created to versioned file
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->