### PR TITLE
ci(timeouts): Add 10 minute timeout to CI unit tests

### DIFF
--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -146,6 +146,7 @@ jobs:
           brew cleanup
 
       - name: Run shellspec Tests (chunk ${{ matrix.chunk }})
+        timeout-minutes: 10
         run: |
           # Get test files for this chunk using configured granularity
           CHUNK_FILES=$(./.github/scripts/chunk-tests.sh 4 ${{ matrix.chunk }} --granularity=${{ env.CHUNK_GRANULARITY_MACOS }})
@@ -363,6 +364,7 @@ jobs:
           brew cleanup
 
       - name: Run shellspec tests with coverage (chunk ${{ matrix.chunk }})
+        timeout-minutes: 10
         run: |
           # Get test files for this chunk using configured granularity
           CHUNK_FILES=$(./.github/scripts/chunk-tests.sh 4 ${{ matrix.chunk }} --granularity=${{ env.CHUNK_GRANULARITY }})


### PR DESCRIPTION
Add timeout-minutes: 10 to shellspec test execution steps for both macOS and Ubuntu jobs to prevent hanging tests from blocking CI indefinitely.

- macOS: Run shellspec Tests step
- Ubuntu: Run shellspec tests with coverage step

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `timeout-minutes: 10` to both the macOS and Ubuntu shellspec test execution steps to prevent hanging tests from blocking CI indefinitely.

**Key changes:**
- `.github/workflows/shellspec.yaml:149` - Added timeout to "Run shellspec Tests (chunk ${{ matrix.chunk }})" step (macOS job)
- `.github/workflows/shellspec.yaml:367` - Added timeout to "Run shellspec tests with coverage (chunk ${{ matrix.chunk }})" step (Ubuntu job)

**Impact:**
- Prevents infinite CI job execution if tests hang or enter an infinite loop
- 10-minute timeout provides reasonable buffer for test execution across 4 chunks (14 test spec files total)
- CI jobs will now fail fast if tests exceed the timeout, improving feedback loop
- Applies consistently to both OS platforms for uniform behavior

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change adds a straightforward timeout configuration to prevent CI hanging. The 10-minute timeout is reasonable for the test suite size (14 spec files across 4 chunks). No logic changes, no breaking changes, and follows GitHub Actions best practices.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/shellspec.yaml | Added 10-minute timeout to both macOS and Ubuntu shellspec test execution steps |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant macOS as macOS Runner
    participant Ubuntu as Ubuntu Runner
    participant ShellSpec as ShellSpec Test Suite
    participant KCov as KCov (Coverage)
    
    Note over GHA: PR/Push Event Triggered
    
    par macOS Job (4 chunks)
        GHA->>macOS: Start chunk 0-3
        macOS->>macOS: Setup environment<br/>(Homebrew, Bun, DIRENV)
        macOS->>ShellSpec: Run tests (chunk N)<br/>⏱️ timeout: 10 min
        alt Tests complete within 10 min
            ShellSpec-->>macOS: Test results
            macOS->>GHA: Upload artifacts
        else Tests hang/exceed 10 min
            macOS-->>macOS: ⚠️ Timeout triggered
            macOS->>GHA: Job failed (timeout)
        end
    and Ubuntu Job (4 chunks)
        GHA->>Ubuntu: Start chunk 0-3
        Ubuntu->>Ubuntu: Setup environment<br/>(Homebrew, DIRENV, KCov)
        Ubuntu->>ShellSpec: Run tests with coverage (chunk N)<br/>⏱️ timeout: 10 min
        ShellSpec->>KCov: Generate coverage data
        alt Tests complete within 10 min
            KCov-->>Ubuntu: Coverage report
            Ubuntu->>GHA: Upload to Codecov
            Ubuntu->>GHA: Upload artifacts
        else Tests hang/exceed 10 min
            Ubuntu-->>Ubuntu: ⚠️ Timeout triggered
            Ubuntu->>GHA: Job failed (timeout)
        end
    end
    
    Note over GHA: Previously: No timeout = infinite wait<br/>Now: 10 min timeout prevents CI blockage
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->