### PR TITLE
refactor: hooks functions

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,7 +1,6 @@
 --require spec_helper
 --shell bash
 --format t
---profile
 --skip-message quiet
 --pending-message quiet
 --output junit

--- a/demos/ci-mode/ci-10-compile.sh
+++ b/demos/ci-mode/ci-10-compile.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Demo CI Script: ci-10-compile.sh
+## Demonstrates the CI script pattern with hooks and mode support
+
+#region Initialization
+# Resolve E_BASH path
+[ -z "$E_BASH" ] && readonly E_BASH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.scripts && pwd)"
+
+# Set DEBUG for visibility (in real scripts, this would be configurable)
+export DEBUG="${DEBUG:-hooks,exec,dry,ci}"
+
+# Source e-bash modules
+# shellcheck disable=SC1090
+source "$E_BASH/_colors.sh"
+# shellcheck disable=SC1090
+source "$E_BASH/_logger.sh"
+# shellcheck disable=SC1090
+source "$E_BASH/_dryrun.sh"
+# shellcheck disable=SC1090
+source "$E_BASH/_hooks.sh"
+# shellcheck disable=SC1090
+source "$E_BASH/_traps.sh"
+
+# Initialize CI logger using e-bash logger module
+logger:init ci "${cl_blue}[ci-10]${cl_reset} " ">&2"
+#endregion
+
+#region CI Script Boilerplate
+# Script identification
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}" .sh)"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configure hooks directory and EXECUTION MODE
+# CRITICAL: Use source mode so mode hooks can export DRY_RUN back to parent
+export HOOKS_EXEC_MODE="source"
+export HOOKS_DIR="${SCRIPT_DIR}/hooks"
+
+# Define hooks: begin, end are mandatory; decide, rollback are optional
+hooks:declare begin end decide rollback
+
+# Register end hook via trap to ensure it runs even on crash/early exit
+# Note: trap:on passes exit_code as first argument to handlers
+__ci_on_exit() {
+  local exit_code="${1:-$?}"  # Receive from trap:on or fallback to $?
+  hooks:do end "${exit_code}"
+  local status="$([[ $exit_code -ne 0 ]] && echo "${cl_red}✗ " || echo "${cl_green}✓ ")"
+  echo:Ci -e "\n${status}${SCRIPT_NAME:-script} finished, exit code: ${exit_code}${cl_reset}\n"
+  return $exit_code
+}
+trap:on __ci_on_exit EXIT
+
+
+# Create dry-run wrappers for commands we'll use
+dry-run npm node tsc echo
+
+# Ensure hook scripts are executable
+for hook_script in "${HOOKS_DIR}"/begin_*.sh "${HOOKS_DIR}"/end_*.sh; do
+  [[ -f "$hook_script" ]] && chmod +x "$hook_script"
+done
+#endregion
+
+#region Hooks Execution: BEGIN
+echo:Ci ""
+echo:Ci "${st_b}=== ${SCRIPT_NAME} ===${st_no_b}"
+echo:Ci ""
+
+# Execute begin hooks (includes mode intercept)
+# Pass script name as argument for mode resolution
+hooks:do begin "${SCRIPT_NAME}"
+
+# Check if mode hooks requested termination (OK, SKIP, ERROR, TEST modes)
+if [[ "${__CI_MODE_TERMINATE:-}" == "true" ]]; then
+  echo:Ci "Mode requested early termination (exit: ${__CI_MODE_EXIT:-0})"
+  exit "${__CI_MODE_EXIT:-0}"
+fi
+#endregion
+
+#region Decision Point: Should Skip?
+# Decision hook example - check if compilation is needed
+hook:decide() {
+  local decision="Continue"
+  
+  # Example: skip if no source changes
+  # In real scenario, this would check git diff or timestamps
+  if [[ "${CI_FORCE_BUILD:-}" != "true" ]] && [[ -f ".build-cache" ]]; then
+    echo:Ci "Build cache found, checking if rebuild needed..."
+    # Simulate cache check
+    decision="Skip"
+  fi
+  
+  echo "$decision"
+}
+
+DECISION=$(hooks:do decide)
+echo:Ci "Decision hook returned: ${DECISION}"
+
+if [[ "${DECISION}" == "Skip" ]]; then
+  echo:Ci "Skipping compilation (cached)"
+  exit 0  # trap will call hooks:do end
+fi
+#endregion
+
+#region Main Logic
+echo:Ci ""
+echo:Ci "Starting compilation..."
+
+# These commands respect DRY_RUN mode
+dry:npm install --prefer-offline
+dry:npm run lint
+dry:tsc --build
+
+echo:Ci "Compilation complete!"
+#endregion
+
+#region Rollback Registration
+# Register rollback commands (only execute if UNDO_RUN=true)
+hook:rollback() {
+  echo:Ci "Rollback: cleaning build artifacts..."
+  rm -rf dist node_modules/.cache
+}
+#endregion
+
+# Script ends here - trap will call hooks:do end and show status

--- a/demos/ci-mode/demo.ci-modes.sh
+++ b/demos/ci-mode/demo.ci-modes.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Demo runner: shows all CI script modes in action
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CI_SCRIPT="${SCRIPT_DIR}/ci-10-compile.sh"
+
+# Resolve E_BASH
+[ -z "$E_BASH" ] && readonly E_BASH="$(cd "${SCRIPT_DIR}" && cd ../../.scripts && pwd)"
+
+# shellcheck disable=SC1090
+source "$E_BASH/_colors.sh"
+
+echo ""
+echo "${cl_lblue}${st_b}╔═══════════════════════════════════════════════════════════╗${st_no_b}${cl_reset}"
+echo "${cl_lblue}${st_b}║       CI Script Mode Demo - e-bash Integration            ║${st_no_b}${cl_reset}"
+echo "${cl_lblue}${st_b}╚═══════════════════════════════════════════════════════════╝${st_no_b}${cl_reset}"
+echo ""
+
+divider() {
+  echo ""
+  echo "${cl_grey}───────────────────────────────────────────────────${cl_reset}"
+  echo ""
+}
+
+#region Mode 1: EXEC (Default)
+echo "${cl_cyan}${st_b}▶ Mode 1: EXEC (default - normal execution)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=EXEC ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE=EXEC "$CI_SCRIPT"
+
+divider
+#endregion
+
+#region Mode 2: DRY
+echo "${cl_cyan}${st_b}▶ Mode 2: DRY (dry-run - preview commands)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=DRY ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE=DRY "$CI_SCRIPT"
+
+divider
+#endregion
+
+#region Mode 3: OK
+echo "${cl_cyan}${st_b}▶ Mode 3: OK (no-op - immediate success)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=OK ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE=OK "$CI_SCRIPT"
+echo "${cl_green}  Exit code: $?${cl_reset}"
+
+divider
+#endregion
+
+#region Mode 4: ERROR
+echo "${cl_cyan}${st_b}▶ Mode 4: ERROR (fail with code)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=ERROR CI_SCRIPT_ERROR_CODE=42 ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE=ERROR CI_SCRIPT_ERROR_CODE=42 "$CI_SCRIPT" || true
+echo "${cl_red}  Exit code: $?${cl_reset}"
+
+divider
+#endregion
+
+#region Mode 5: SKIP
+echo "${cl_cyan}${st_b}▶ Mode 5: SKIP (disabled step)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=SKIP ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE=SKIP "$CI_SCRIPT"
+echo "${cl_yellow}  Exit code: $?${cl_reset}"
+
+divider
+#endregion
+
+#region Mode 6: TIMEOUT
+echo "${cl_cyan}${st_b}▶ Mode 6: TIMEOUT (fail after N seconds)${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=TIMEOUT:2 ./ci-10-compile.sh${cl_reset}"
+echo "${cl_yellow}  Note: This would timeout after 2s if script took longer${cl_reset}"
+divider
+
+CI_SCRIPT_MODE="TIMEOUT:60" "$CI_SCRIPT"  # Using 60s to not actually timeout
+echo "${cl_green}  Completed before timeout. Exit code: $?${cl_reset}"
+
+divider
+#endregion
+
+#region Mode 7: Per-script override
+echo "${cl_cyan}${st_b}▶ Mode 7: Per-script override${st_no_b}${cl_reset}"
+echo "${cl_grey}  Command: CI_SCRIPT_MODE_ci_10_compile=DRY CI_SCRIPT_MODE=EXEC ./ci-10-compile.sh${cl_reset}"
+echo "${cl_yellow}  Note: Script-specific mode (DRY) overrides global (EXEC)${cl_reset}"
+divider
+
+CI_SCRIPT_MODE_ci_10_compile=DRY CI_SCRIPT_MODE=EXEC "$CI_SCRIPT"
+
+divider
+#endregion
+
+#region Mode 8: TEST (mock script)
+echo "${cl_cyan}${st_b}▶ Mode 8: TEST (run mock script instead)${st_no_b}${cl_reset}"
+
+# Create a temporary mock script
+MOCK_SCRIPT=$(mktemp)
+cat > "$MOCK_SCRIPT" << 'EOF'
+echo "[MOCK] This is a test mock script"
+echo "[MOCK] Simulating successful build..."
+echo "[MOCK] Build artifacts: dist/app.js"
+__CI_MODE_EXIT_CODE=0
+EOF
+
+echo "${cl_grey}  Command: CI_SCRIPT_MODE=${MOCK_SCRIPT} ./ci-10-compile.sh${cl_reset}"
+divider
+
+CI_SCRIPT_MODE="$MOCK_SCRIPT" "$CI_SCRIPT"
+echo "${cl_green}  Exit code: $?${cl_reset}"
+
+rm -f "$MOCK_SCRIPT"
+
+divider
+#endregion
+
+echo ""
+echo "${cl_lblue}${st_b}Demo complete!${st_no_b}${cl_reset}"
+echo ""
+echo "Key takeaways:"
+echo "  ${cl_green}✓${cl_reset} All modes handled via begin hook (${cl_cyan}begin_00_mode-intercept.sh${cl_reset})"
+echo "  ${cl_green}✓${cl_reset} Scripts use e-bash modules: dryrun, hooks, logger"
+echo "  ${cl_green}✓${cl_reset} Per-script overrides: CI_SCRIPT_MODE_{script_name}"
+echo "  ${cl_green}✓${cl_reset} Decision hooks support conditional execution"
+echo "  ${cl_green}✓${cl_reset} Rollback registration for UNDO mode"
+echo ""

--- a/demos/ci-mode/hooks/begin_00_mode-resolve.sh
+++ b/demos/ci-mode/hooks/begin_00_mode-resolve.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_00_mode-resolve.sh (source mode)
+## Purpose: Resolve CI_SCRIPT_MODE from environment variables
+## Sets: __CI_SCRIPT_MODE for other hooks to check
+
+function hook:run() {
+  local script_name="${1:-unknown}"
+  local script_name_safe="${script_name//[^a-zA-Z0-9_]/_}"
+
+  # Mode resolution: per-script > global > default (EXEC)
+  local mode_var="CI_SCRIPT_MODE_${script_name_safe}"
+  __CI_SCRIPT_MODE="${!mode_var:-${CI_SCRIPT_MODE:-EXEC}}"
+  export __CI_SCRIPT_MODE
+
+  echo "[mode] Resolved: script='${script_name}' mode='${__CI_SCRIPT_MODE}'" >&2
+}

--- a/demos/ci-mode/hooks/begin_10_mode-dry.sh
+++ b/demos/ci-mode/hooks/begin_10_mode-dry.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_10_mode-dry.sh (source mode)
+## Purpose: Handle DRY mode - enable dry-run for all commands
+
+function hook:run() {
+  [[ "${__CI_SCRIPT_MODE}" != "DRY" ]] && return 0
+
+  echo "[mode] DRY: enabling dry-run for all commands" >&2
+  export DRY_RUN=true
+}

--- a/demos/ci-mode/hooks/begin_11_mode-ok.sh
+++ b/demos/ci-mode/hooks/begin_11_mode-ok.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_11_mode-ok.sh (source mode)
+## Purpose: Handle OK mode - no-op, exit parent with success
+
+function hook:run() {
+  [[ "${__CI_SCRIPT_MODE}" != "OK" ]] && return 0
+
+  echo "[mode] OK: no-op, exiting with success" >&2
+  # In source mode, we can't exit the parent - set flag instead
+  export __CI_MODE_EXIT=0
+  export __CI_MODE_TERMINATE=true
+}

--- a/demos/ci-mode/hooks/begin_12_mode-error.sh
+++ b/demos/ci-mode/hooks/begin_12_mode-error.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_12_mode-error.sh (source mode)
+## Purpose: Handle ERROR mode - exit parent with specified error code
+
+function hook:run() {
+  [[ "${__CI_SCRIPT_MODE}" != "ERROR" ]] && return 0
+
+  local error_code="${CI_SCRIPT_ERROR_CODE:-1}"
+  echo "[mode] ERROR: exiting with code ${error_code}" >&2
+  export __CI_MODE_EXIT="${error_code}"
+  export __CI_MODE_TERMINATE=true
+}

--- a/demos/ci-mode/hooks/begin_13_mode-skip.sh
+++ b/demos/ci-mode/hooks/begin_13_mode-skip.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_13_mode-skip.sh (source mode)
+## Purpose: Handle SKIP mode - disabled step, exit parent with success
+
+function hook:run() {
+  [[ "${__CI_SCRIPT_MODE}" != "SKIP" ]] && return 0
+
+  echo "[mode] SKIP: step disabled, exiting" >&2
+  export __CI_MODE_EXIT=0
+  export __CI_MODE_TERMINATE=true
+}

--- a/demos/ci-mode/hooks/begin_14_mode-timeout.sh
+++ b/demos/ci-mode/hooks/begin_14_mode-timeout.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_14_mode-timeout.sh (source mode)
+## Purpose: Handle TIMEOUT mode - fail after N seconds
+
+function hook:run() {
+  [[ "${__CI_SCRIPT_MODE}" != TIMEOUT:* ]] && return 0
+
+  local timeout_secs="${__CI_SCRIPT_MODE#TIMEOUT:}"
+  echo "[mode] TIMEOUT: will fail after ${timeout_secs}s" >&2
+
+  export CI_SCRIPT_TIMEOUT="${timeout_secs}"
+  
+  # Schedule alarm signal in background (target parent shell)
+  ( sleep "${timeout_secs}" && kill -ALRM $PPID 2>/dev/null ) &
+  export __CI_TIMEOUT_PID=$!
+
+  # Set up trap in parent shell 
+  trap 'echo "[mode] TIMEOUT: Script exceeded ${CI_SCRIPT_TIMEOUT}s" >&2; exit 124' ALRM
+}

--- a/demos/ci-mode/hooks/begin_15_mode-test.sh
+++ b/demos/ci-mode/hooks/begin_15_mode-test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Hook: begin_15_mode-test.sh (source mode)
+## Purpose: Handle TEST mode - run mock script instead
+
+function hook:run() {
+  # Check if mode is a file path (TEST mode)
+  [[ ! -f "${__CI_SCRIPT_MODE}" ]] && return 0
+
+  echo "[mode] TEST: sourcing ${__CI_SCRIPT_MODE}" >&2
+  # shellcheck disable=SC1090
+  source "${__CI_SCRIPT_MODE}"
+  export __CI_MODE_EXIT="${__CI_MODE_EXIT_CODE:-0}"
+  export __CI_MODE_TERMINATE=true
+}

--- a/demos/ci-mode/hooks/end_99_timeout-cleanup.sh
+++ b/demos/ci-mode/hooks/end_99_timeout-cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2025-12-19
+## Version: 1.12.1
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+## Global end hook: Cleanup timeout background process (source mode)
+
+function hook:run() {
+  if [[ -n "${__CI_TIMEOUT_PID}" ]]; then
+    echo "[mode] Cleaning up timeout watcher (PID: ${__CI_TIMEOUT_PID})" >&2
+    kill "${__CI_TIMEOUT_PID}" 2>/dev/null || true
+  fi
+}

--- a/demos/demo.hooks-logging.sh
+++ b/demos/demo.hooks-logging.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.0.0
+## Last revisit: 2025-12-19
+## Version: 1.12.1
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -30,7 +30,7 @@ echo "${cl_cyan}${st_b}Example 1: Hook Definition and Execution Logging${st_no_b
 echo "----------------------------------------"
 echo ""
 
-hooks:define begin process end
+hooks:declare begin process end
 
 echo ""
 echo "${cl_grey}# Implementing function hooks${cl_reset}"
@@ -44,9 +44,9 @@ hook:end() {
 
 echo ""
 echo "${cl_grey}# Executing hooks${cl_reset}"
-on:hook begin
+hooks:do begin
 echo "  ${cl_green}[User Output] Main logic here...${cl_reset}"
-on:hook end
+hooks:do end
 
 echo ""
 
@@ -88,7 +88,7 @@ echo "${cl_grey}#  - Execution order (1/3, 2/3, 3/3)${cl_reset}"
 echo "${cl_grey}#  - Exit codes for each script${cl_reset}"
 echo ""
 
-on:hook process
+hooks:do process
 
 rm -rf "$DEMO_DIR"
 
@@ -105,7 +105,7 @@ export HOOKS_EXEC_MODE="source"
 echo "${cl_yellow}HOOKS_EXEC_MODE=\"source\"${cl_reset} - Scripts are sourced, not executed"
 echo ""
 
-hooks:define deploy
+hooks:declare deploy
 
 DEMO_SOURCE_DIR="/tmp/demo_hooks_source_$$"
 mkdir -p "$DEMO_SOURCE_DIR"
@@ -132,7 +132,7 @@ echo "${cl_grey}# Script contains hook:run function${cl_reset}"
 echo "${cl_grey}# Logging shows '(sourced mode)' indicator${cl_reset}"
 echo ""
 
-on:hook deploy "v1.2.3"
+hooks:do deploy "v1.2.3"
 
 echo ""
 echo "${cl_green}After sourced execution, variables are accessible:${cl_reset}"
@@ -152,7 +152,7 @@ echo "${cl_cyan}${st_b}Example 4: Failed Hook with Exit Code Logging${st_no_b}${
 echo "----------------------------------------"
 echo ""
 
-hooks:define validate
+hooks:declare validate
 
 DEMO_FAIL_DIR="/tmp/demo_hooks_fail_$$"
 mkdir -p "$DEMO_FAIL_DIR"
@@ -169,7 +169,7 @@ chmod +x "$DEMO_FAIL_DIR/validate-check.sh"
 echo "${cl_grey}# Exit code is logged for debugging${cl_reset}"
 echo ""
 
-if on:hook validate; then
+if hooks:do validate; then
   echo "  ${cl_green}Validation passed${cl_reset}"
 else
   EXIT_CODE=$?

--- a/demos/demo.hooks-nested.sh
+++ b/demos/demo.hooks-nested.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.0.0
+## Last revisit: 2025-12-19
+## Version: 1.12.1
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -39,7 +39,7 @@ cat > /tmp/demo_library.sh <<'EOF'
 source "$E_BASH/_hooks.sh"
 
 # Library defines its own hooks
-hooks:define init cleanup process
+hooks:declare init cleanup process
 
 # Library provides implementations
 hook:init() {
@@ -75,7 +75,7 @@ echo "Main script also defines init, cleanup, and process hooks..."
 echo
 
 # Main script defines the same hooks - this will trigger warnings
-hooks:define init cleanup process
+hooks:declare init cleanup process
 
 # Main script provides its own implementations
 hook:init() {
@@ -101,15 +101,15 @@ echo "${cl_green}Example 3: Executing Hooks (Both Implementations Run)${cl_reset
 echo
 
 echo "${cl_yellow}→ Executing init hook:${cl_reset}"
-on:hook init
+hooks:do init
 echo
 
 echo "${cl_yellow}→ Executing process hook:${cl_reset}"
-on:hook process
+hooks:do process
 echo
 
 echo "${cl_yellow}→ Executing cleanup hook:${cl_reset}"
-on:hook cleanup
+hooks:do cleanup
 echo
 
 #
@@ -131,7 +131,7 @@ echo
 cat > /tmp/demo_helper.sh <<'EOF'
 #!/usr/bin/env bash
 source "$E_BASH/_hooks.sh"
-hooks:define init
+hooks:declare init
 
 hook:init() {
   echo "  [Helper] Helper initialization"
@@ -143,7 +143,7 @@ source /tmp/demo_helper.sh
 echo
 
 echo "${cl_yellow}→ Now executing init with THREE contexts:${cl_reset}"
-on:hook init
+hooks:do init
 echo
 
 echo "${cl_yellow}→ Listing hooks shows 3 contexts:${cl_reset}"
@@ -165,7 +165,7 @@ echo
 echo "Example scenario:"
 echo "  1. Library initializes database connection (hook:init)"
 echo "  2. Main script initializes application state (hook:init)"
-echo "  3. on:hook init runs BOTH in sequence"
+echo "  3. hooks:do init runs BOTH in sequence"
 echo "  4. Both components are properly initialized!"
 echo
 
@@ -176,8 +176,8 @@ echo "${cl_green}Example 7: Re-defining Hook in Same Context${cl_reset}"
 echo "If the same context defines a hook twice, no warning is shown..."
 echo
 
-hooks:define test_hook
-hooks:define test_hook  # Same context, no warning
+hooks:declare test_hook
+hooks:declare test_hook  # Same context, no warning
 
 echo
 

--- a/demos/demo.hooks-registration.sh
+++ b/demos/demo.hooks-registration.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.0.0
+## Last revisit: 2025-12-19
+## Version: 1.12.1
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -41,15 +41,15 @@ notification_sender() {
 }
 
 # Define hook and register functions
-hooks:define deploy
+hooks:declare deploy
 
 echo "Registering functions for 'deploy' hook..."
-hook:register deploy "10-metrics" metrics_tracker
-hook:register deploy "20-notify" notification_sender
+hooks:register deploy "10-metrics" metrics_tracker
+hooks:register deploy "20-notify" notification_sender
 echo
 
 echo "${cl_yellow}→ Executing deploy hook:${cl_reset}"
-on:hook deploy "production"
+hooks:do deploy "production"
 echo
 
 #
@@ -63,17 +63,17 @@ func_charlie() { echo "  → Charlie (30)"; }
 func_alpha() { echo "  → Alpha (10)"; }
 func_bravo() { echo "  → Bravo (20)"; }
 
-hooks:define test
+hooks:declare test
 
 # Register out of order
 echo "Registering: charlie (30), alpha (10), bravo (20)..."
-hook:register test "30-charlie" func_charlie
-hook:register test "10-alpha" func_alpha
-hook:register test "20-bravo" func_bravo
+hooks:register test "30-charlie" func_charlie
+hooks:register test "10-alpha" func_alpha
+hooks:register test "20-bravo" func_bravo
 echo
 
 echo "${cl_yellow}→ Execution order (alphabetical by friendly name):${cl_reset}"
-on:hook test
+hooks:do test
 echo
 
 #
@@ -106,15 +106,15 @@ forward_to_slack() {
   /tmp/slack-notify.sh "$@"
 }
 
-hooks:define notify
+hooks:declare notify
 
 echo "Registering external script forwarders..."
-hook:register notify "datadog" forward_to_datadog
-hook:register notify "slack" forward_to_slack
+hooks:register notify "datadog" forward_to_datadog
+hooks:register notify "slack" forward_to_slack
 echo
 
 echo "${cl_yellow}→ Executing notify hook with parameters:${cl_reset}"
-on:hook notify "deploy_success" "v1.2.3"
+hooks:do notify "deploy_success" "v1.2.3"
 echo
 
 #
@@ -137,9 +137,9 @@ post_build_metrics() {
   echo "  📊 [Registered] Collecting build metrics"
 }
 
-hooks:define build
-hook:register build "00-pre" pre_build_check
-hook:register build "99-post" post_build_metrics
+hooks:declare build
+hooks:register build "00-pre" pre_build_check
+hooks:register build "99-post" post_build_metrics
 
 echo "Execution order:"
 echo "  1. hook:build() function"
@@ -148,7 +148,7 @@ echo "  3. External scripts (if any)"
 echo
 
 echo "${cl_yellow}→ Executing build hook:${cl_reset}"
-on:hook build
+hooks:do build
 echo
 
 #
@@ -168,21 +168,21 @@ development_shortcuts() {
   echo "  ⚡ [Dev] Using dev credentials"
 }
 
-hooks:define validate
+hooks:declare validate
 
 # Register functions based on environment
 ENVIRONMENT="${ENVIRONMENT:-development}"
 echo "Current environment: ${ENVIRONMENT}"
 
 if [[ "$ENVIRONMENT" == "production" ]]; then
-  hook:register validate "prod-checks" production_checks
+  hooks:register validate "prod-checks" production_checks
 else
-  hook:register validate "dev-shortcuts" development_shortcuts
+  hooks:register validate "dev-shortcuts" development_shortcuts
 fi
 echo
 
 echo "${cl_yellow}→ Executing validate hook:${cl_reset}"
-on:hook validate
+hooks:do validate
 echo
 
 #
@@ -199,20 +199,20 @@ permanent_function() {
   echo "  ✓ [Permanent] This will always run"
 }
 
-hooks:define cleanup
-hook:register cleanup "temp" temporary_function
-hook:register cleanup "perm" permanent_function
+hooks:declare cleanup
+hooks:register cleanup "temp" temporary_function
+hooks:register cleanup "perm" permanent_function
 
 echo "Before unregister:"
-on:hook cleanup
+hooks:do cleanup
 echo
 
 echo "Unregistering 'temp' function..."
-hook:unregister cleanup "temp"
+hooks:unregister cleanup "temp"
 echo
 
 echo "After unregister:"
-on:hook cleanup
+hooks:do cleanup
 echo
 
 #
@@ -221,10 +221,10 @@ echo
 echo "${cl_green}Example 7: Listing Hooks with Registrations${cl_reset}"
 echo
 
-hooks:define final
-hook:register final "10-first" metrics_tracker
-hook:register final "20-second" notification_sender
-hook:register final "30-third" forward_to_datadog
+hooks:declare final
+hooks:register final "10-first" metrics_tracker
+hooks:register final "20-second" notification_sender
+hooks:register final "30-third" forward_to_datadog
 
 echo "${cl_yellow}→ Hooks list shows registration count:${cl_reset}"
 hooks:list
@@ -247,10 +247,10 @@ add_timing() {
   }"
 
   # Register it to run first (00- prefix)
-  hook:register "$hook_name" "00-timing" "$timing_func"
+  hooks:register "$hook_name" "00-timing" "$timing_func"
 }
 
-hooks:define process
+hooks:declare process
 add_timing process
 
 # Add main logic
@@ -264,7 +264,7 @@ echo "Added timing observability to 'process' hook"
 echo
 
 echo "${cl_yellow}→ Executing process hook with timing:${cl_reset}"
-on:hook process
+hooks:do process
 echo
 
 #
@@ -276,7 +276,7 @@ rm -f /tmp/datadog-notify.sh /tmp/slack-notify.sh
 echo "${cl_green}Demo complete!${cl_reset}"
 echo
 echo "Key Takeaways:"
-echo "  • hook:register <hook> <friendly_name> <function>"
+echo "  • hooks:register <hook> <friendly_name> <function>"
 echo "  • Functions execute in alphabetical order by friendly_name"
 echo "  • Perfect for metrics, logging, and external integrations"
 echo "  • Can be registered/unregistered dynamically"

--- a/demos/demo.hooks.sh
+++ b/demos/demo.hooks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-18
-## Version: 1.0.0
+## Last revisit: 2025-12-19
+## Version: 1.12.1
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -25,7 +25,7 @@ echo "${cl_cyan}${st_b}Example 1: Basic Hook Definition${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
 # Define available hooks
-hooks:define begin end
+hooks:declare begin end
 
 echo "✓ Defined hooks: begin, end"
 echo ""
@@ -41,9 +41,9 @@ hook:end() {
 
 # Execute hooks
 echo "Calling hooks:"
-on:hook begin
+hooks:do begin
 echo "  ${cl_grey}[Main script logic here]${cl_reset}"
-on:hook end
+hooks:do end
 
 echo ""
 
@@ -53,7 +53,7 @@ echo ""
 echo "${cl_cyan}${st_b}Example 2: Hooks with Parameters${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
-hooks:define greet
+hooks:declare greet
 
 hook:greet() {
   local name="$1"
@@ -62,8 +62,8 @@ hook:greet() {
 }
 
 echo "Calling hook with parameters:"
-on:hook greet "Alice" "Dr."
-on:hook greet "Bob"
+hooks:do greet "Alice" "Dr."
+hooks:do greet "Bob"
 
 echo ""
 
@@ -73,7 +73,7 @@ echo ""
 echo "${cl_cyan}${st_b}Example 3: Decision Hooks${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
-hooks:define decide
+hooks:declare decide
 
 hook:decide() {
   local question="$1"
@@ -82,7 +82,7 @@ hook:decide() {
 }
 
 echo "Using decision hook:"
-if [[ "$(on:hook decide "Should we continue?")" == "yes" ]]; then
+if [[ "$(hooks:do decide "Should we continue?")" == "yes" ]]; then
   echo "  ${cl_green}✓ Decision was YES - proceeding${cl_reset}"
 else
   echo "  ${cl_red}✗ Decision was NO - stopping${cl_reset}"
@@ -96,7 +96,7 @@ echo ""
 echo "${cl_cyan}${st_b}Example 4: Error Handling${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
-hooks:define error rollback
+hooks:declare error rollback
 
 hook:error() {
   local message="$1"
@@ -110,8 +110,8 @@ hook:rollback() {
 }
 
 echo "Simulating error scenario:"
-on:hook error "Database connection failed" 42
-on:hook rollback
+hooks:do error "Database connection failed" 42
+hooks:do rollback
 
 echo ""
 
@@ -122,7 +122,7 @@ echo "${cl_cyan}${st_b}Example 5: Hook Introspection${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
 # Define some hooks without implementations
-hooks:define implemented not_implemented custom_hook
+hooks:declare implemented not_implemented custom_hook
 
 hook:implemented() {
   echo "This hook has an implementation"
@@ -134,15 +134,15 @@ hooks:list
 echo ""
 
 echo "Checking specific hooks:"
-if hooks:is_defined implemented; then
+if hooks:known implemented; then
   echo "  ${cl_green}✓ 'implemented' hook is defined${cl_reset}"
 fi
 
-if hooks:has_implementation implemented; then
+if hooks:runnable implemented; then
   echo "  ${cl_green}✓ 'implemented' hook has an implementation${cl_reset}"
 fi
 
-if ! hooks:has_implementation not_implemented; then
+if ! hooks:runnable not_implemented; then
   echo "  ${cl_yellow}! 'not_implemented' hook has NO implementation${cl_reset}"
 fi
 
@@ -155,13 +155,13 @@ echo "${cl_cyan}${st_b}Example 6: Silent Skipping${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
 echo "Calling undefined hook (silently skipped):"
-on:hook undefined_hook "param1" "param2"
+hooks:do undefined_hook "param1" "param2"
 echo "  ${cl_green}✓ Script continued without error${cl_reset}"
 
 echo ""
 
 echo "Calling defined but not implemented hook:"
-on:hook not_implemented
+hooks:do not_implemented
 echo "  ${cl_green}✓ Script continued without error${cl_reset}"
 
 echo ""
@@ -172,7 +172,7 @@ echo ""
 echo "${cl_cyan}${st_b}Example 7: Lifecycle Pattern${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
-hooks:define pre_validate validate post_validate pre_process process post_process
+hooks:declare pre_validate validate post_validate pre_process process post_process
 
 hook:pre_validate() {
   echo "  ${cl_grey}→ Pre-validation setup${cl_reset}"
@@ -201,13 +201,13 @@ hook:post_process() {
 }
 
 echo "Executing lifecycle hooks:"
-on:hook pre_validate
-on:hook validate && echo "  ${cl_green}✓ Validation passed${cl_reset}"
-on:hook post_validate
+hooks:do pre_validate
+hooks:do validate && echo "  ${cl_green}✓ Validation passed${cl_reset}"
+hooks:do post_validate
 
-on:hook pre_process
-on:hook process && echo "  ${cl_green}✓ Processing complete${cl_reset}"
-on:hook post_process
+hooks:do pre_process
+hooks:do process && echo "  ${cl_green}✓ Processing complete${cl_reset}"
+hooks:do post_process
 
 echo ""
 
@@ -217,7 +217,7 @@ echo ""
 echo "${cl_cyan}${st_b}Example 8: Return Values and Exit Codes${st_no_b}${cl_reset}"
 echo "----------------------------------------"
 
-hooks:define success_hook failure_hook
+hooks:declare success_hook failure_hook
 
 hook:success_hook() {
   echo "  ${cl_green}→ Success hook returning 0${cl_reset}"
@@ -230,11 +230,11 @@ hook:failure_hook() {
 }
 
 echo "Testing exit codes:"
-on:hook success_hook
+hooks:do success_hook
 success_code=$?
 echo "  Exit code: $success_code ${cl_green}(success)${cl_reset}"
 
-on:hook failure_hook
+hooks:do failure_hook
 failure_code=$?
 echo "  Exit code: $failure_code ${cl_red}(failure)${cl_reset}"
 
@@ -251,7 +251,7 @@ DEMO_HOOKS_DIR="/tmp/demo_cicd_$$"
 mkdir -p "$DEMO_HOOKS_DIR"
 export HOOKS_DIR="$DEMO_HOOKS_DIR"
 
-hooks:define deploy
+hooks:declare deploy
 
 # Create multiple hook scripts with numbered pattern
 cat > "$DEMO_HOOKS_DIR/deploy_01_backup.sh" <<'EOF'
@@ -289,8 +289,8 @@ echo "  deploy_04_start.sh"
 echo "  deploy-verify.sh"
 echo ""
 
-echo "Executing: ${cl_cyan}on:hook deploy${cl_reset}"
-on:hook deploy
+echo "Executing: ${cl_cyan}hooks:do deploy${cl_reset}"
+hooks:do deploy
 
 echo ""
 echo "Listing hooks:"
@@ -325,7 +325,7 @@ echo ""
 echo "${cl_lblue}${st_b}=== Summary ===${st_no_b}${cl_reset}"
 echo ""
 echo "The hooks system provides:"
-echo "  • ${cl_green}Declarative hook definition${cl_reset} via hooks:define"
+echo "  • ${cl_green}Declarative hook definition${cl_reset} via hooks:declare"
 echo "  • ${cl_green}Flexible implementation${cl_reset} via functions or scripts"
 echo "  • ${cl_green}Silent skipping${cl_reset} of undefined/unimplemented hooks"
 echo "  • ${cl_green}Parameter passing${cl_reset} to hook implementations"
@@ -334,11 +334,11 @@ echo "  • ${cl_green}Introspection capabilities${cl_reset} for dynamic behavio
 echo "  • ${cl_green}Multiple scripts per hook${cl_reset} with ci-cd pattern"
 echo ""
 echo "Usage patterns:"
-echo "  1. ${cl_cyan}hooks:define${cl_reset} hook1 hook2 ...    # Declare hooks"
-echo "  2. ${cl_cyan}on:hook${cl_reset} hook_name [params]     # Execute hook"
+echo "  1. ${cl_cyan}hooks:declare${cl_reset} hook1 hook2 ...    # Declare hooks"
+echo "  2. ${cl_cyan}hooks:do${cl_reset} hook_name [params]     # Execute hook"
 echo "  3. ${cl_cyan}hooks:list${cl_reset}                     # List all hooks"
-echo "  4. ${cl_cyan}hooks:is_defined${cl_reset} hook_name    # Check if defined"
-echo "  5. ${cl_cyan}hooks:has_implementation${cl_reset} name # Check if implemented"
+echo "  4. ${cl_cyan}hooks:known${cl_reset} hook_name    # Check if defined"
+echo "  5. ${cl_cyan}hooks:runnable${cl_reset} name # Check if implemented"
 echo ""
 echo "CI/CD Script Naming Patterns:"
 echo "  • ${cl_yellow}ci-cd/{hook_name}-{purpose}.sh${cl_reset}        - Simple pattern"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Comprehensive refactor of hooks system API naming for better clarity and consistency. All public functions renamed: `hooks:define` → `hooks:declare`, `on:hook` → `hooks:do`, `hook:as:source/script` → `hooks:pattern:source/script`, `hooks:is_defined` → `hooks:known`, `hooks:has_implementation` → `hooks:runnable`, `hooks:cleanup` → `hooks:reset`, `hooks:get_exec_mode` → `hooks:exec:mode`, and source/script hook execution variants.

**Key changes:**
- Renamed 11 public API functions to use consistent `hooks:*` namespace with clearer action verbs
- Updated all documentation (hooks.md), demos (4 files), and tests (hooks_spec.sh) to reflect new naming
- Added comprehensive CI-mode demo with 7 new hook scripts showing practical integration patterns
- Enhanced README with before/after example demonstrating 4-line hooks integration
- Fixed critical bug in `_traps.sh:Trap::dispatch()` where exit code wasn't captured before local variable assignments
- Version numbers changed to 1.12.1 across 20 files (decreased from 1.17.7 - likely unintentional)

**Impact:**
This is a breaking API change requiring all users to update function calls. The new naming is more intuitive (`hooks:do` vs `on:hook`) and follows consistent namespace patterns (`hooks:pattern:source` vs `hook:as:source`).

<h3>Confidence Score: 3/5</h3>


- Safe to merge after fixing critical version number regression
- The refactoring is thorough and well-executed with comprehensive test and documentation updates. However, the version number decreased from 1.17.7 to 1.12.1 which violates semantic versioning principles. Given this is a breaking API change, the version should be bumped to 2.0.0 instead. All functional changes are sound, but this versioning issue must be corrected before merging.
- `.scripts/_hooks.sh` - version number must be corrected from 1.12.1 to 2.0.0 (or higher) to reflect breaking changes. Same version fix needed in `.scripts/_traps.sh` and all demo files for consistency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .scripts/_hooks.sh | Renamed all public APIs (hooks:define → hooks:declare, on:hook → hooks:do, etc.). Version downgraded from 1.17.7 to 1.12.1 (likely unintentional). Added TODOs for future improvements. |
| .scripts/_traps.sh | Critical fix: captures exit code before any commands in Trap::dispatch. Passes exit_code to handlers and returns original exit code. Version bumped to 1.12.1. |
| spec/hooks_spec.sh | Updated all test calls to use new API names (hooks:declare, hooks:do, hooks:known, hooks:runnable). Tests verify the refactored hook system works correctly. |
| docs/public/hooks.md | Comprehensive documentation update reflecting new API names. All code examples and usage patterns updated to use hooks:declare, hooks:do, hooks:known, hooks:runnable. |
| README.md | Added new Hooks section with before/after example showing 4-line integration. Demonstrates .hooks/ directory pattern with practical examples (OTEL, Slack, metrics). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User Script
    participant Hooks as _hooks.sh
    participant Func as hook:{name} Function
    participant RegFunc as Registered Functions
    participant Scripts as Hook Scripts (ci-cd/)
    
    User->>Hooks: hooks:declare begin end deploy
    Note over Hooks: Store hook names in<br/>__HOOKS_DEFINED array
    
    User->>User: Define hook:begin() function
    User->>Hooks: hooks:register deploy "10-backup" backup_fn
    Note over Hooks: Store in __HOOKS_REGISTERED
    
    User->>Hooks: hooks:do begin param1
    Note over Hooks: Check __HOOKS_DEFINED[begin]
    
    Hooks->>Func: Call hook:begin(param1)
    Func-->>Hooks: return exit_code
    
    Hooks->>RegFunc: Call registered functions<br/>(alphabetical order)
    loop For each registration
        RegFunc->>RegFunc: Execute backup_fn(param1)
        RegFunc-->>Hooks: return exit_code
    end
    
    Hooks->>Scripts: Find ci-cd/begin-*.sh scripts
    loop For each script (alphabetical)
        alt exec mode
            Hooks->>Scripts: Execute script as subprocess
            Scripts-->>Hooks: exit_code
        else source mode
            Hooks->>Scripts: Source script, call hook:run()
            Scripts-->>Hooks: exit_code
        end
    end
    
    Hooks-->>User: return last_exit_code
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->