### PR TITLE
refactor: Refactor dryrun script naming and functions

### DIFF
--- a/demos/demo.dryrun-modes.sh
+++ b/demos/demo.dryrun-modes.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
-## Version: 1.0.0
+## Last revisit: 2025-12-30
+## Version: 0.15.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -17,12 +17,12 @@ source "$E_BASH/_dryrun.sh"
 
 logger:init demo "${cl_blue}[DEMO]${cl_reset} " ">&2"
 
-echo:Demo "Testing dry-run wrapper three-mode system..."
+echo:Demo "Testing dryrun wrapper three-mode system..."
 echo:Demo ""
 
 # Create wrappers for commands
 echo:Demo "Creating wrappers for ls and git commands..."
-dry-run ls git
+dryrun ls git
 echo:Demo ""
 
 # ============================================================================
@@ -46,12 +46,12 @@ echo:Demo "Test 1.3: rollback:git status (should be dry-run)"
 rollback:git status
 
 echo:Demo ""
-echo:Demo "Test 1.4: rollback:func (should be dry-run)"
+echo:Demo "Test 1.4: undo:func (should be dry-run)"
 function sample_rollback() {
   echo "This would undo changes"
   return 0
 }
-rollback:func sample_rollback
+undo:func sample_rollback
 
 # ============================================================================
 # MODE 2: Dry-Run Mode
@@ -75,8 +75,8 @@ echo:Demo "Test 2.3: rollback:git status (should be dry-run)"
 DRY_RUN=true rollback:git status
 
 echo:Demo ""
-echo:Demo "Test 2.4: rollback:func (should be dry-run)"
-DRY_RUN=true rollback:func sample_rollback
+echo:Demo "Test 2.4: undo:func (should be dry-run)"
+DRY_RUN=true undo:func sample_rollback
 
 # ============================================================================
 # MODE 3: Undo/Rollback Mode
@@ -104,8 +104,8 @@ echo:Demo "Test 3.4: undo:git status (should EXECUTE)"
 UNDO_RUN=true undo:git status
 
 echo:Demo ""
-echo:Demo "Test 3.5: rollback:func (should EXECUTE)"
-UNDO_RUN=true rollback:func sample_rollback
+echo:Demo "Test 3.5: undo:func (should EXECUTE)"
+UNDO_RUN=true undo:func sample_rollback
 
 # ============================================================================
 # MODE 4: Combined modes (edge case testing)
@@ -121,8 +121,8 @@ echo:Demo "Test 4.1: rollback:git status (should be dry-run)"
 DRY_RUN=true UNDO_RUN=true rollback:git status
 
 echo:Demo ""
-echo:Demo "Test 4.2: rollback:func (should be dry-run)"
-DRY_RUN=true UNDO_RUN=true rollback:func sample_rollback
+echo:Demo "Test 4.2: undo:func (should be dry-run)"
+DRY_RUN=true UNDO_RUN=true undo:func sample_rollback
 
 # ============================================================================
 # MODE 5: Command-specific overrides

--- a/demos/demo.dryrun-v2.sh
+++ b/demos/demo.dryrun-v2.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-11-28
-## Version: 1.0.0
+## Last revisit: 2025-12-30
+## Version: 0.15.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -17,11 +17,11 @@ source "$E_BASH/_dryrun.sh"
 
 logger:init demo "${cl_blue}[DEMO]${cl_reset} "
 
-echo:Demo "Starting dry-run wrapper demonstration..."
+echo:Demo "Starting dryrun wrapper demonstration..."
 
 # Create wrappers for ls and git commands
 echo:Demo "Creating wrappers for ls and git commands..."
-dry-run ls git
+dryrun ls git
 
 echo:Demo "Wrappers created successfully!"
 echo:Demo ""
@@ -59,7 +59,7 @@ function rollback_step() {
   git log --oneline -1
   pwd
 }
-DRY_RUN=true rollback:func rollback_step
+DRY_RUN=true undo:func rollback_step
 
 echo:Demo ""
 echo:Demo "=== Example 5: Custom suffixes ==="

--- a/spec/dryrun_spec.sh
+++ b/spec/dryrun_spec.sh
@@ -4,8 +4,8 @@
 # shellcheck disable=SC2317,SC2016,SC2288
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-26
-## Version: 1.14.0
+## Last revisit: 2025-12-30
+## Version: 0.15.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -109,9 +109,9 @@ Describe "_dryrun.sh /"
     End
   End
 
-  Describe "dryrun:exec function /"
+  Describe "_dryrun:exec function /"
     It "Should execute command successfully and return exit code"
-      When call dryrun:exec "Test" "false" "echo" "hello world"
+      When call _dryrun:exec "Test" "false" "echo" "hello world"
 
       The status should be success
       The output should eq "hello world"
@@ -120,7 +120,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should handle command failure and return correct exit code"
-      When call dryrun:exec "Test" "false" "exit" "1"
+      When call _dryrun:exec "Test" "false" "exit" "1"
 
       The status should eq 1
       The output should eq ""
@@ -129,7 +129,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should display output when not in silent mode"
-      When call dryrun:exec "Test" "false" "echo" "test output"
+      When call _dryrun:exec "Test" "false" "echo" "test output"
 
       The status should be success
       The output should eq "test output"
@@ -138,7 +138,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should suppress output when in silent mode"
-      When call dryrun:exec "Test" "true" "echo" "test output"
+      When call _dryrun:exec "Test" "true" "echo" "test output"
 
       The status should be success
       The output should eq ""
@@ -148,7 +148,7 @@ Describe "_dryrun.sh /"
 
     It "Should preserve errexit setting"
       BeforeCall "set -e"
-      When call dryrun:exec "Test" "false" "echo" "preserved errexit"
+      When call _dryrun:exec "Test" "false" "echo" "preserved errexit"
 
       The status should be success
       The output should eq "preserved errexit"
@@ -157,7 +157,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should handle command with arguments containing spaces"
-      When call dryrun:exec "Test" "false" "echo" "hello world with spaces"
+      When call _dryrun:exec "Test" "false" "echo" "hello world with spaces"
 
       The status should be success
       The output should eq "hello world with spaces"
@@ -166,7 +166,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should handle command with no arguments"
-      When call dryrun:exec "Test" "false" "pwd"
+      When call _dryrun:exec "Test" "false" "pwd"
 
       The status should be success
       The output should include "/"
@@ -175,9 +175,9 @@ Describe "_dryrun.sh /"
     End
   End
 
-  Describe "dry-run function generator /"
+  Describe "dryrun function generator /"
     It "Should generate wrapper functions for a single command"
-      When call dry-run "testcmd"
+      When call dryrun "testcmd"
 
       The status should be success
       The function run:testcmd should be defined
@@ -187,7 +187,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should generate wrapper functions for multiple commands"
-      When call dry-run "cmd1" "cmd2" "cmd3"
+      When call dryrun "cmd1" "cmd2" "cmd3"
 
       The status should be success
       The function run:cmd1 should be defined
@@ -205,7 +205,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should use custom suffix when provided"
-      When call dry-run "mycmd" "CUSTOM"
+      When call dryrun "mycmd" "CUSTOM"
 
       The status should be success
       The function run:mycmd should be defined
@@ -215,7 +215,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should convert command name to uppercase for default suffix"
-      When call dry-run "testcommand"
+      When call dryrun "testcommand"
 
       The status should be success
       The function run:testcommand should be defined
@@ -223,7 +223,7 @@ Describe "_dryrun.sh /"
   End
 
   Describe "Generated functions behavior /"
-    BeforeEach "dry-run 'echo' 'pwd'"
+    BeforeEach "dryrun 'echo' 'pwd'"
 
     Describe "run: functions in normal mode /"
       BeforeEach "export DRY_RUN=false UNDO_RUN=false SILENT=false"
@@ -342,7 +342,7 @@ Describe "_dryrun.sh /"
   End
 
   Describe "Per-command environment variable overrides /"
-    BeforeEach "dry-run 'echo'"
+    BeforeEach "dryrun 'echo'"
 
     It "Should use DRY_RUN_ECHO override when set"
       BeforeCall "export DRY_RUN_ECHO=true DRY_RUN=false"
@@ -391,10 +391,10 @@ Describe "_dryrun.sh /"
     End
   End
 
-  Describe "rollback:func function /"
+  Describe "undo:func function /"
     It "Should not execute function when UNDO_RUN=false"
       BeforeCall "export UNDO_RUN=false DRY_RUN=false"
-      When call rollback:func "test_function" "arg1" "arg2"
+      When call undo:func "test_function" "arg1" "arg2"
 
       The status should be success
       The output should include "(dry-func): test_function arg1 arg2"
@@ -402,7 +402,7 @@ Describe "_dryrun.sh /"
 
     It "Should not execute function when DRY_RUN=true"
       BeforeCall "export UNDO_RUN=true DRY_RUN=true"
-      When call rollback:func "test_function" "arg1" "arg2"
+      When call undo:func "test_function" "arg1" "arg2"
 
       The status should be success
       The output should include "(dry-func): test_function arg1 arg2"
@@ -410,7 +410,7 @@ Describe "_dryrun.sh /"
 
     It "Should execute function when UNDO_RUN=true and DRY_RUN=false"
       BeforeCall "export UNDO_RUN=true DRY_RUN=false"
-      When call rollback:func "echo" "hello world"
+      When call undo:func "echo" "hello world"
 
       The status should be success
       The output should eq "hello world"
@@ -425,7 +425,7 @@ Describe "_dryrun.sh /"
       }
 
       BeforeCall "export UNDO_RUN=false DRY_RUN=true"
-      When call rollback:func "test_function"
+      When call undo:func "test_function"
 
       The status should be success
       The output should include "(dry-func): test_function"
@@ -434,7 +434,7 @@ Describe "_dryrun.sh /"
 
     It "Should handle non-existent function gracefully"
       BeforeCall "export UNDO_RUN=false DRY_RUN=true"
-      When call rollback:func "non_existent_function"
+      When call undo:func "non_existent_function"
 
       The status should be success
       The output should include "(dry-func): non_existent_function"
@@ -442,7 +442,7 @@ Describe "_dryrun.sh /"
 
     It "Should respect SILENT setting"
       BeforeCall "export UNDO_RUN=true DRY_RUN=false SILENT=true"
-      When call rollback:func "echo" "silent rollback"
+      When call undo:func "echo" "silent rollback"
 
       The status should be success
       The output should eq ""
@@ -454,7 +454,7 @@ Describe "_dryrun.sh /"
   Describe "Complex scenarios and edge cases /"
     It "Should handle mixed global and per-command settings"
       BeforeCall "export DRY_RUN=true UNDO_RUN=false SILENT=false"
-      BeforeCall "dry-run 'echo' 'pwd'"
+      BeforeCall "dryrun 'echo' 'pwd'"
       BeforeCall "export DRY_RUN_PWD=false"
 
       When call dry:echo "dry global"
@@ -464,7 +464,7 @@ Describe "_dryrun.sh /"
 
     It "Should respect per-command override over global settings"
       BeforeCall "export DRY_RUN=true UNDO_RUN=false SILENT=false"
-      BeforeCall "dry-run 'echo' 'pwd'"
+      BeforeCall "dryrun 'echo' 'pwd'"
       BeforeCall "export DRY_RUN_PWD=false"
 
       When call dry:pwd
@@ -475,7 +475,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should handle command names with special characters"
-      When call dry-run "test-cmd" "test_cmd" "test123"
+      When call dryrun "test-cmd" "test_cmd" "test123"
 
       The status should be success
       The function run:test-cmd should be defined
@@ -484,7 +484,7 @@ Describe "_dryrun.sh /"
     End
 
     It "Should handle empty command arguments"
-      BeforeCall "dry-run 'echo'"
+      BeforeCall "dryrun 'echo'"
 
       When call run:echo
       The status should be success
@@ -494,7 +494,7 @@ Describe "_dryrun.sh /"
 
     It "Should preserve shell options correctly"
       BeforeCall "set -e"
-      BeforeCall "dry-run 'echo'"
+      BeforeCall "dryrun 'echo'"
       BeforeCall "export DRY_RUN=false UNDO_RUN=false"
 
       When call run:echo "test with errexit"
@@ -508,9 +508,9 @@ Describe "_dryrun.sh /"
 
   Describe "Integration with logger system /"
     It "Should use correct logger tags for different operations"
-      # The dryrun:exec function uses printf:Exec for command logging
+      # The _dryrun:exec function uses printf:Exec for command logging
       # This tests that the logger integration works
-      When call dryrun:exec "TestLogger" "false" "echo" "logger test"
+      When call _dryrun:exec "TestLogger" "false" "echo" "logger test"
 
       The status should be success
       The output should eq "logger test"
@@ -520,11 +520,33 @@ Describe "_dryrun.sh /"
 
     It "Should respect DEBUG environment for logger output"
       BeforeCall "export DEBUG=Exec"
-      When call dryrun:exec "Exec" "false" "echo" "debug test"
+      When call _dryrun:exec "Exec" "false" "echo" "debug test"
 
       The status should be success
       The output should eq "debug test"
       The error should include "echo debug test"
+      The error should include "code: 0"
+    End
+  End
+
+  Describe "Backward compatibility /"
+    It "Should support old dry-run function name"
+      When call dry-run "testcmd"
+
+      The status should be success
+      The function run:testcmd should be defined
+      The function dry:testcmd should be defined
+      The function rollback:testcmd should be defined
+      The function undo:testcmd should be defined
+    End
+
+    It "Should support old rollback:func function name"
+      BeforeCall "export UNDO_RUN=true DRY_RUN=false"
+      When call rollback:func "echo" "backward compatible"
+
+      The status should be success
+      The output should eq "backward compatible"
+      The error should include "echo backward compatible"
       The error should include "code: 0"
     End
   End


### PR DESCRIPTION
- Rename `dry-run` to `dryrun` (more consistent with module naming)
- Rename `rollback:func` to `undo:func` (clearer intent)
- Rename `dryrun:exec` to `_dryrun:exec` (mark as internal function)
- Add backward compatibility aliases for old names
- Update all tests to use new function names
- Add backward compatibility tests
- Update documentation with new names and compatibility notes
- Update demo scripts to demonstrate new naming

Breaking changes: None (backward compatibility maintained via aliases)

BREAKING CHANGE: The preferred function names have changed, but old names are still supported. New code should use `dryrun` instead of `dry-run`, and `undo:func` instead of `rollback:func`. The internal function `dryrun:exec` is now `_dryrun:exec` and should not be called directly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors the dryrun module naming for improved consistency and clarity:

**Function Renamings:**
- `dry-run` → `dryrun` (aligns with module naming convention `_dryrun.sh`)
- `rollback:func` → `undo:func` (clearer semantic meaning)
- `dryrun:exec` → `_dryrun:exec` (underscore prefix marks as internal/private)

**Key Changes:**
- Backward compatibility maintained via function aliases (`dry-run` calls `dryrun`, `rollback:func` calls `undo:func`)
- All internal references updated to use new names
- Comprehensive test coverage for both new names and backward compatibility
- Documentation updated with migration guidance
- Demo scripts updated to demonstrate new API

**Implementation Quality:**
- Version bumped from 1.14.0 to 0.15.0 (breaking change marker)
- All 5 files updated consistently
- Tests include dedicated backward compatibility suite
- Documentation clearly notes old names still supported

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a well-executed refactoring with complete backward compatibility. All old function names are preserved as aliases, comprehensive tests verify both new and old APIs work correctly, and documentation clearly explains the changes. The implementation is clean, consistent across all files, and follows the project's established patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .scripts/_dryrun.sh | Renamed functions for clarity: `dryrun:exec` → `_dryrun:exec` (internal), `dry-run` → `dryrun`, `rollback:func` → `undo:func`. Backward compatibility aliases added for old names. |
| spec/dryrun_spec.sh | Updated all tests to use new function names. Added comprehensive backward compatibility test suite for `dry-run` and `rollback:func` aliases. |
| docs/public/dryrun-wrapper.md | Updated documentation to reflect new naming convention (`dryrun`, `undo:func`). Added backward compatibility notes explaining that old names still work. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User Script
    participant New as New Functions<br/>(dryrun, undo:func)
    participant Old as Old Aliases<br/>(dry-run, rollback:func)
    participant Internal as Internal (_dryrun:exec)
    participant Wrappers as Generated Wrappers<br/>(run:cmd, dry:cmd, rollback:cmd)
    
    Note over User,Wrappers: Function Naming Refactor with Backward Compatibility
    
    User->>New: dryrun "git" "docker"
    activate New
    New->>Wrappers: Generate run:git, dry:git, rollback:git
    New->>Wrappers: Generate undo:git alias
    New->>Internal: Uses _dryrun:exec (internal)
    Wrappers-->>New: Functions created
    deactivate New
    New-->>User: Wrappers ready
    
    Note over User,Old: Backward Compatible Path
    
    User->>Old: dry-run "kubectl"
    activate Old
    Old->>New: Calls dryrun("kubectl")
    activate New
    New->>Wrappers: Generate run:kubectl, dry:kubectl
    New->>Wrappers: Generate rollback:kubectl + undo:kubectl
    Wrappers-->>New: Functions created
    deactivate New
    New-->>Old: Success
    deactivate Old
    Old-->>User: Wrappers ready
    
    Note over User,Wrappers: Execution Flow (New API)
    
    User->>Wrappers: run:git status
    Wrappers->>Internal: _dryrun:exec("Exec", false, "git", "status")
    Internal->>Internal: Execute command
    Internal-->>Wrappers: Result + exit code
    Wrappers-->>User: Output
    
    User->>New: undo:func cleanup_fn
    New->>Internal: _dryrun:exec("Undo", ...)
    Internal-->>New: Result
    New-->>User: Output
    
    Note over User,Old: Execution Flow (Old API via Aliases)
    
    User->>Old: rollback:func restore_fn
    activate Old
    Old->>New: Calls undo:func(restore_fn)
    activate New
    New->>Internal: _dryrun:exec("Undo", ...)
    Internal-->>New: Result
    deactivate New
    New-->>Old: Result
    deactivate Old
    Old-->>User: Output
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->