### PR TITLE
fix: resolve macOS CI test failures due to wc -l and grep -c whitespace

### DIFF
--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -61,6 +61,10 @@ jobs:
       - name: Install direnv
         shell: bash
         run: |
+          # Install latest bash via Homebrew to ensure consistent behavior across platforms
+          brew install bash
+
+          # Install direnv for Ubuntu (must be after Homebrew for dependency order)
           curl -sfL https://direnv.net/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -139,6 +143,10 @@ jobs:
 
       - name: Install direnv
         run: |
+          # Install latest bash to ensure consistent behavior across platforms
+          brew install bash
+
+          # Install direnv for macOS
           brew install direnv
 
       - name: Setup project dependencies (direnv)

--- a/.scripts/_commons.sh
+++ b/.scripts/_commons.sh
@@ -3,7 +3,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2025-12-30
-## Version: 1.18.1
+## Version: 2.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -964,8 +964,11 @@ function config:hierarchy() {
     stop_path="/"
     ;;
   /*)
-    # Absolute path provided
-    stop_path="$stop_at"
+    # Absolute path provided - resolve to physical path (like current_dir)
+    stop_path=$(cd "$stop_at" 2>/dev/null && pwd -P) || {
+      echo ""
+      return 1
+    }
     ;;
   *)
     # Relative path or invalid, fallback to git

--- a/spec/commons_spec.sh
+++ b/spec/commons_spec.sh
@@ -5,7 +5,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2025-12-30
-## Version: 2.0.0
+## Version: 2.0.2
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -1970,7 +1970,7 @@ Describe "_commons.sh /"
 
       result=$(config:hierarchy ".myconfig" "$test_root" "root")
       cleanup_test_configs "$test_root"
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       # Helper function for numeric comparison
       check_count() { test "$1" -ge 3; }
@@ -2067,7 +2067,7 @@ Describe "_commons.sh /"
       cleanup_xdg_test "$test_root"
 
       first_line=$(echo "$result" | head -n 1)
-      has_subdir=$(echo "$first_line" | grep -c "subdir/myapp.json" || true)
+      has_subdir=$(count_matches "subdir/myapp.json" "$first_line")
 
       When call echo "$has_subdir"
 
@@ -2081,7 +2081,7 @@ Describe "_commons.sh /"
       result=$(call_xdg_with_home "$test_root" "myapp" "config" "$test_root/project" "root" ".json")
       cleanup_xdg_test "$test_root"
 
-      has_xdg=$(echo "$result" | grep -c "\.config/myapp/config.json" || true)
+      has_xdg=$(count_matches "\.config/myapp/config.json" "$result")
 
       When call echo "$has_xdg"
 
@@ -2097,7 +2097,7 @@ Describe "_commons.sh /"
       result=$(call_xdg_with_home "$test_root" --xdg "$test_root/custom-xdg" "myapp" "config" "$test_root/project" "root" ".json")
       cleanup_xdg_test "$test_root"
 
-      has_custom_xdg=$(echo "$result" | grep -c "custom-xdg/myapp/config.json" || true)
+      has_custom_xdg=$(count_matches "custom-xdg/myapp/config.json" "$result")
 
       When call echo "$has_custom_xdg"
 
@@ -2117,7 +2117,7 @@ Describe "_commons.sh /"
       result=$(config:hierarchy:xdg "myapp" "config" "$test_root/project" "root" ".json")
       cleanup_xdg_test "$test_root"
 
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       # Helper for comparison
       check_ge_1() { test "$1" -ge 1; }
@@ -2136,7 +2136,7 @@ Describe "_commons.sh /"
       result=$(call_xdg_with_home "$test_root" "myapp" "config,myapprc" "$test_root/project" "root" ".json")
       cleanup_xdg_test "$test_root"
 
-      count=$(echo "$result" | grep -c "\.config/myapp/" || true)
+      count=$(count_matches "\.config/myapp/" "$result")
 
       # Helper for comparison
       check_ge_2() { test "$1" -ge 2; }
@@ -2202,7 +2202,7 @@ Describe "_commons.sh /"
       cleanup_xdg_test "$test_root"
 
       # Should still find hierarchical configs
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       # Helper for comparison
       check_ge_1() { test "$1" -ge 1; }
@@ -2220,7 +2220,7 @@ Describe "_commons.sh /"
       result=$(call_xdg_with_home "$test_root" "nvim" "init.vim" "$test_root/project" "home" "")
       cleanup_xdg_test "$test_root"
 
-      has_nvim=$(echo "$result" | grep -c "\.config/nvim/init.vim" || true)
+      has_nvim=$(count_matches "\.config/nvim/init.vim" "$result")
 
       When call echo "$has_nvim"
 
@@ -2236,7 +2236,7 @@ Describe "_commons.sh /"
       cleanup_xdg_test "$test_root"
 
       # XDG directories under HOME should still be searched
-      has_xdg=$(echo "$result" | grep -c "\.config/myapp" || true)
+      has_xdg=$(count_matches "\.config/myapp" "$result")
 
       # Helper for comparison
       check_ge_0() { test "$1" -ge 0; }

--- a/spec/commons_spec.sh
+++ b/spec/commons_spec.sh
@@ -5,7 +5,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2025-12-30
-## Version: 1.17.1
+## Version: 2.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -1860,7 +1860,7 @@ Describe "_commons.sh /"
 
       result=$(config:hierarchy ".myconfig,.altconfig" "$test_root/level1/level2/level3" "root" ".json")
       cleanup_test_configs "$test_root"
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       When call echo "$count"
 
@@ -1875,8 +1875,8 @@ Describe "_commons.sh /"
       result=$(config:hierarchy ".myconfig" "$test_root/level1/level2/level3" "root" ".json,.yaml")
       cleanup_test_configs "$test_root"
 
-      has_json=$(echo "$result" | grep -c "\.json$" || true)
-      has_yaml=$(echo "$result" | grep -c "\.yaml$" || true)
+      has_json=$(count_matches "\.json$" "$result")
+      has_yaml=$(count_matches "\.yaml$" "$result")
 
       When call echo "$has_json,$has_yaml"
 
@@ -1896,7 +1896,7 @@ Describe "_commons.sh /"
 
       result=$(config:hierarchy ".myconfig" "$test_root/level1/level2/level3" "$test_root/level1" ".json")
       cleanup_test_configs "$test_root"
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       When call echo "$count"
 
@@ -1925,7 +1925,7 @@ Describe "_commons.sh /"
       result=$(config:hierarchy "myconfig" "$test_root/level1/level2/level3" "root" ",.json")
       cleanup_test_configs "$test_root"
 
-      has_exact=$(echo "$result" | grep -c "/myconfig$" || true)
+      has_exact=$(count_matches "/myconfig$" "$result")
 
       When call echo "$has_exact"
 
@@ -1941,8 +1941,8 @@ Describe "_commons.sh /"
       last_file=$(echo "$result" | tail -n 1)
       cleanup_test_configs "$test_root"
 
-      first_is_root=$(echo "$first_file" | grep -c "^$test_root/\.myconfig\.json$" || true)
-      last_is_level3=$(echo "$last_file" | grep -c "level3/\.myconfig\.json$" || true)
+      first_is_root=$(count_matches "^${test_root}/\.myconfig\.json$" "$first_file")
+      last_is_level3=$(count_matches "level3/\.myconfig\.json$" "$last_file")
 
       When call echo "$first_is_root,$last_is_level3"
 
@@ -1955,7 +1955,7 @@ Describe "_commons.sh /"
 
       result=$(config:hierarchy " .myconfig , .altconfig " "$test_root/level1/level2/level3" "root" ".json")
       cleanup_test_configs "$test_root"
-      count=$(echo "$result" | wc -l)
+      count=$(count_lines "$result")
 
       When call echo "$count"
 

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -3,8 +3,8 @@
 # shellcheck shell=bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-23
-## Version: 1.12.6
+## Last revisit: 2025-12-30
+## Version: 2.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -99,4 +99,19 @@ strip_colors() {
 script_sourced() {
   # Mock the source guard test
   [[ "${BASH_SOURCE[0]}" != "${0}" ]]
+}
+
+# Cross-platform helper: count lines in output
+# macOS wc -l adds leading whitespace, this strips it
+count_lines() {
+  local input="$1"
+  echo "$input" | wc -l | tr -d ' '
+}
+
+# Cross-platform helper: count matches in output
+# macOS grep -c adds leading whitespace, this strips it
+count_matches() {
+  local pattern="$1"
+  local input="$2"
+  echo "$input" | grep -c "$pattern" 2>/dev/null | tr -d ' ' || echo "0"
 }


### PR DESCRIPTION
## Summary
Fixes failing `config:hierarchy` tests on macOS by addressing two cross-platform compatibility issues:

- **macOS `wc -l` and `grep -c` add leading whitespace** - POSIX-compliant tools on macOS pad output with spaces
- **`stop_path` not resolved with `pwd -P`** - Custom stop_at paths weren't resolved to physical paths like search_dir

## Changes

### spec/spec_helper.sh
- Added `count_lines()` helper - strips whitespace from `wc -l` output
- Added `count_matches()` helper - strips whitespace from `grep -c` output

### spec/commons_spec.sh
- Updated 6 tests to use new cross-platform helpers instead of raw `wc -l`/`grep -c`
- Tests affected: "searches multiple config names", "tries multiple extensions", "stops at custom path", "includes empty extension", "respects order", "handles whitespace in config names"

### .scripts/_commons.sh
- Fixed `config:hierarchy` to resolve absolute stop_at paths with `pwd -P`
- Ensures stop_path and search_dir use comparable physical paths

## Test Results
All 237 tests in `spec/commons_spec.sh` now pass on Ubuntu. macOS CI will verify cross-platform compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes macOS CI test failures caused by POSIX-compliant `wc -l` and `grep -c` adding leading whitespace to their output on macOS.

## Key Changes

- **spec/spec_helper.sh**: Added `count_lines()` and `count_matches()` helpers that strip whitespace using `tr -d ' '` for cross-platform compatibility
- **.scripts/_commons.sh**: Fixed `config:hierarchy()` to resolve absolute `stop_at` paths with `pwd -P`, matching how `search_dir` is resolved (line 968)
- **spec/commons_spec.sh**: Updated 6 tests in `config:hierarchy` to use new helpers

## Critical Issue Found

**The fix is incomplete.** While 6 `config:hierarchy` tests were updated, **8 additional instances** in `config:hierarchy:xdg` tests (lines 1973, 2070, 2084, 2100, 2120, 2139, 2205, 2223, 2239) still use raw `wc -l`/`grep -c` and will fail on macOS CI with the same whitespace issue. These need to be updated to use `count_lines()` and `count_matches()` helpers for complete cross-platform compatibility.

The `_commons.sh` change is correct and necessary - absolute paths like `$test_root/level1` need physical path resolution to match the canonicalized `search_dir` path.

<h3>Confidence Score: 3/5</h3>


- This PR partially addresses the macOS CI issues but leaves 8 tests unfixed that will still fail on macOS
- Score of 3 reflects that while the approach is correct (helpers work, `_commons.sh` fix is solid), the implementation is incomplete. The PR claims to fix "config:hierarchy tests on macOS" but only updates 6 of 14 affected tests. The remaining 8 `config:hierarchy:xdg` tests will still fail on macOS CI with the same whitespace comparison issues. The fix needs to be applied consistently across all tests that use `wc -l` and `grep -c`.
- spec/commons_spec.sh requires immediate attention - 8 more tests need the same helper function updates applied (lines 1973, 2070, 2084, 2100, 2120, 2139, 2205, 2223, 2239)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| spec/spec_helper.sh | Added cross-platform helpers `count_lines()` and `count_matches()` to handle macOS whitespace from `wc -l`/`grep -c` |
| spec/commons_spec.sh | Updated 6 `config:hierarchy` tests to use new helpers, but missed 8 more instances in `config:hierarchy:xdg` tests (lines 1973, 2070, 2084, 2100, 2120, 2139, 2205, 2223, 2239) |
| .scripts/_commons.sh | Fixed `stop_at` path resolution to use `pwd -P` for absolute paths, matching how `search_dir` is resolved |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as ShellSpec Test
    participant Helper as spec_helper.sh
    participant Function as config:hierarchy()
    participant WC as wc/grep (macOS)
    
    Note over Test,WC: macOS CI Test Execution Flow
    
    Test->>Function: config:hierarchy(".myconfig", "/path", "root", ".json")
    Function->>Function: Resolve stop_at="/path" using pwd -P
    Note right of Function: New: Uses pwd -P for<br/>absolute paths (line 968)
    Function->>Function: Search directory hierarchy
    Function-->>Test: Return: "/root/.myconfig.json\n/path/.myconfig.json"
    
    Note over Test,Helper: OLD APPROACH (macOS fails)
    Test->>WC: echo "$result" | wc -l
    WC-->>Test: "     2" (with leading spaces)
    Test->>Test: Compare "     2" == "2" ❌ FAIL
    
    Note over Test,Helper: NEW APPROACH (cross-platform)
    Test->>Helper: count_lines("$result")
    Helper->>WC: echo "$input" | wc -l
    WC-->>Helper: "     2" (with leading spaces)
    Helper->>Helper: tr -d ' ' strips whitespace
    Helper-->>Test: "2" (clean output)
    Test->>Test: Compare "2" == "2" ✅ PASS
    
    Note over Test,Helper: grep -c Pattern (similar fix)
    Test->>Helper: count_matches("\.json$", "$result")
    Helper->>WC: echo "$input" | grep -c pattern
    WC-->>Helper: "     3" (with leading spaces)
    Helper->>Helper: tr -d ' ' strips whitespace
    Helper-->>Test: "3" (clean output)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->