### PR TITLE
fix: Fix/macos ci test whitespace issues

### DIFF
--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -76,6 +76,20 @@ jobs:
           direnv allow .
           direnv export gha >> "$GITHUB_ENV"
 
+      - name: Apply ShellSpec Timeout Patch
+        shell: bash
+        run: |
+          # Apply the timeout feature patch to ShellSpec if not already applied
+          if ! shellspec --help 2>/dev/null | grep -q -- '--timeout'; then
+            echo "Applying ShellSpec timeout patch..."
+            chmod +x patches/apply.sh
+            ./patches/apply.sh
+          else
+            echo "ShellSpec timeout patch already applied"
+          fi
+          # Verify patch is applied
+          shellspec --help | grep -A 2 timeout
+
       - name: Run full ShellSpec suite (with coverage)
         shell: bash
         run: |
@@ -153,6 +167,19 @@ jobs:
         run: |
           direnv allow .
           direnv export gha >> "$GITHUB_ENV"
+
+      - name: Apply ShellSpec Timeout Patch
+        run: |
+          # Apply the timeout feature patch to ShellSpec if not already applied
+          if ! shellspec --help 2>/dev/null | grep -q -- '--timeout'; then
+            echo "Applying ShellSpec timeout patch..."
+            chmod +x patches/apply.sh
+            ./patches/apply.sh
+          else
+            echo "ShellSpec timeout patch already applied"
+          fi
+          # Verify patch is applied
+          shellspec --help | grep -A 2 timeout
 
       - name: Run full ShellSpec suite
         shell: bash

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -4,7 +4,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2025-12-30
-## Version: 2.0.0
+## Version: 2.0.3
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -113,5 +113,7 @@ count_lines() {
 count_matches() {
   local pattern="$1"
   local input="$2"
-  echo "$input" | grep -c "$pattern" 2>/dev/null | tr -d ' ' || echo "0"
+  local count
+  count=$(echo "$input" | grep -c "$pattern" 2>/dev/null) || count=0
+  echo "$count" | tr -d ' '
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR continues the fix for macOS CI test failures by adding two refinements:

1. **Workflow Enhancement**: Added a ShellSpec timeout patch application step to the baseline.yaml workflow (both Linux and macOS jobs). This ensures the timeout feature is available before running the test suite, preventing potential test hangs or timeouts.

2. **Test Helper Robustness**: Fixed the `count_matches()` helper function in `spec/spec_helper.sh` to properly handle the case when `grep -c` returns a non-zero exit code (when no matches are found). The previous implementation would fail due to the `|| echo "0"` being executed within a command substitution that could propagate the error. The new implementation captures the exit code properly and defaults to 0 when grep finds no matches.

The changes are minimal, focused, and address edge cases discovered during CI testing. Version bumped to 2.0.3.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are minimal, well-tested refinements to existing fixes. The workflow patch application is idempotent with proper guards, and the `count_matches` fix correctly handles grep's exit code behavior when no matches are found - a genuine bug fix that prevents test failures. Both changes are defensive improvements with no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/baseline.yaml | Added ShellSpec timeout patch application step to both Linux and macOS jobs before running test suites |
| spec/spec_helper.sh | Fixed `count_matches` to handle grep exit code properly when no matches found, version bumped to 2.0.3 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Direnv as Direnv Setup
    participant Patch as Patch Script
    participant ShellSpec as ShellSpec
    participant Helper as spec_helper.sh
    participant Tests as Test Suite

    Note over GHA,Tests: Baseline Workflow Execution

    GHA->>Direnv: Setup project dependencies
    Direnv-->>GHA: Environment configured
    
    GHA->>Patch: Apply ShellSpec Timeout Patch
    Patch->>ShellSpec: Check if --timeout flag exists
    alt Patch needed
        Patch->>ShellSpec: Apply timeout patch
        Patch->>ShellSpec: Verify functional timeout
        ShellSpec-->>Patch: Patch applied successfully
    else Already patched
        ShellSpec-->>Patch: Skip patching
    end
    Patch-->>GHA: Patch ready
    
    GHA->>Tests: Run ShellSpec suite
    Tests->>Helper: Call count_matches()
    Helper->>Helper: Execute grep -c pattern
    alt No matches found
        Helper->>Helper: grep returns exit code 1
        Helper->>Helper: Capture exit code, set count=0
    else Matches found
        Helper->>Helper: grep returns count
    end
    Helper->>Helper: Strip whitespace with tr -d ' '
    Helper-->>Tests: Return sanitized count
    Tests-->>GHA: Tests complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->