### PR TITLE
fix: run on local macos

### DIFF
--- a/spec/commons_spec.sh
+++ b/spec/commons_spec.sh
@@ -4,8 +4,8 @@
 # shellcheck disable=SC2317,SC2016,SC2288,SC2155,SC2329
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-30
-## Version: 2.0.2
+## Last revisit: 2025-12-31
+## Version: 2.0.3
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -1809,6 +1809,7 @@ Describe "_commons.sh /"
     setup_test_configs() {
       local test_root="/tmp/config-hierarchy-test-$$"
       mkdir -p "$test_root/level1/level2/level3"
+      test_root=$(cd "$test_root" && pwd -P)
 
       echo '{"root": true}' > "$test_root/.myconfig.json"
       echo '{"level1": true}' > "$test_root/level1/.myconfig.json"

--- a/spec/git_semantic_version_spec.sh
+++ b/spec/git_semantic_version_spec.sh
@@ -4,8 +4,8 @@
 # shellcheck disable=SC2155,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2025-12-23
-## Version: 1.12.6
+## Last revisit: 2025-12-31
+## Version: 2.0.3
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -127,6 +127,57 @@ Describe "bin/git.semantic-version.sh /"
     It "returns false for non-breaking change"
       When call gitsv:has_breaking_change "feat: normal feature"
       The status should be failure
+    End
+  End
+
+  Describe "gitsv:extract_breaking_change_line() /"
+    It "returns the BREAKING CHANGE line from the body"
+      When call gitsv:extract_breaking_change_line $'feat: something\n\nBREAKING CHANGE: api change\nmore'
+      The output should eq "BREAKING CHANGE: api change"
+    End
+
+    It "returns empty when no breaking change exists"
+      When call gitsv:extract_breaking_change_line "feat: something"
+      The output should eq ""
+    End
+  End
+
+  Describe "gitsv:truncate_text() /"
+    It "returns original text when under limit"
+      When call gitsv:truncate_text "short" 10
+      The output should eq "short"
+    End
+
+    It "truncates and appends ellipsis when over limit"
+      When call gitsv:truncate_text "0123456789" 8
+      The output should eq "01234..."
+    End
+  End
+
+  Describe "gitsv:format_annotation_marker() /"
+    It "wraps the number in purple brackets"
+      When call gitsv:format_annotation_marker "3"
+      The output should eq "${cl_purple}[3]${cl_reset}"
+    End
+  End
+
+  Describe "gitsv:format_annotation_entry() /"
+    It "adds a hint to show the full commit message"
+      When call gitsv:format_annotation_entry "${cl_purple}[2]${cl_reset}" "found BREAKING CHANGE: api" "abc1234"
+      The result of function no_colors_stdout should include "[2] - found BREAKING CHANGE: api..."
+      The result of function no_colors_stdout should include "full message: git show -s --format=%B abc1234"
+    End
+  End
+
+  Describe "gitsv:breaking_change_annotation() /"
+    It "returns annotation when breaking change is hidden in body"
+      When call gitsv:breaking_change_annotation $'feat: foo\n\nBREAKING CHANGE: api change' "feat: foo"
+      The output should include "found BREAKING CHANGE: api change"
+    End
+
+    It "returns empty when breaking change is not hidden"
+      When call gitsv:breaking_change_annotation "BREAKING CHANGE: api change" "BREAKING CHANGE: api change"
+      The output should eq ""
     End
   End
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed macOS compatibility issue with shellspec directory detection and test path resolution.

- Enhanced `find_shellspec_dir()` in `patches/apply.macos.sh` to detect manual install scenario (Case 1) where the shellspec binary is in the root directory with `lib/core/core.sh` in the same directory
- Fixed `setup_test_configs()` in `spec/commons_spec.sh` to use `pwd -P` for resolving symlinks, ensuring consistent absolute path handling across different environments (macOS/Linux)

<h3>Confidence Score: 5/5</h3>


- Safe to merge - focused bug fixes with clear logic improvements
- Both changes are well-documented improvements that address specific edge cases. The shellspec directory detection adds a missing case for manual installs, and the test path resolution fix ensures symlinks are properly resolved for consistent testing
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| patches/apply.macos.sh | Improved shellspec directory detection logic to handle manual install case (binary in root directory) |
| spec/commons_spec.sh | Fixed test to resolve symlinks using `pwd -P` for consistent path handling across environments |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ApplyMacOS as patches/apply.macos.sh
    participant ShellSpec as ShellSpec Binary
    participant FileSystem as File System
    participant Test as commons_spec.sh

    Note over ApplyMacOS: Patch Application Flow
    User->>ApplyMacOS: Execute patch script
    ApplyMacOS->>ShellSpec: command -v shellspec
    ShellSpec-->>ApplyMacOS: Return binary path
    ApplyMacOS->>ApplyMacOS: Resolve symlinks recursively
    ApplyMacOS->>FileSystem: Check bin_dir/lib/core/core.sh (Case 1: Manual install)
    alt Manual install found
        FileSystem-->>ApplyMacOS: File exists
        ApplyMacOS-->>User: Return bin_dir
    else Check standard install
        ApplyMacOS->>FileSystem: Check install_root/lib/core/core.sh (Case 2: Standard)
        alt Standard install found
            FileSystem-->>ApplyMacOS: File exists
            ApplyMacOS-->>User: Return install_root
        else Check Homebrew
            ApplyMacOS->>FileSystem: Check install_root/lib/shellspec/lib/core/core.sh (Case 3: Homebrew)
            FileSystem-->>ApplyMacOS: File exists or fallback
            ApplyMacOS-->>User: Return appropriate path
        end
    end

    Note over Test: Test Setup Flow
    User->>Test: Run ShellSpec tests
    Test->>Test: setup_test_configs()
    Test->>FileSystem: mkdir -p test_root/level1/level2/level3
    Test->>Test: cd test_root && pwd -P (resolve symlinks)
    Test->>FileSystem: Create .myconfig.json files
    Test-->>User: Tests execute with resolved paths
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->