### PR TITLE
feat: Fix semantic version script tag capture

### DIFF
--- a/.scripts/_gnu.sh
+++ b/.scripts/_gnu.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-07
-## Version: 2.0.0
+## Last revisit: 2026-01-15
+## Version: 2.0.1
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -11,13 +11,14 @@
 # when running on Linux, providing ggrep/gsed commands for compatibility
 #
 
-# Only proceed if we're on Linux
+# Determine gnubin directory path
+BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/gnubin"
+
+# Always create gnubin directory (even on macOS) to prevent cd errors
+mkdir -p "$BIN_DIR"
+
+# Only create symlinks on Linux
 if [[ "$(uname -s)" == "Linux" ]]; then
-  BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/bin/gnubin"
-
-  # Create bin directory if it doesn't exist
-  mkdir -p "$BIN_DIR"
-
   TOOLS=("grep" "sed" "find" "awk" "mv" "cp" "ln" "readlink" "date")
 
   for tool in "${TOOLS[@]}"; do

--- a/bin/git.semantic-version.sh
+++ b/bin/git.semantic-version.sh
@@ -5,8 +5,8 @@
 ## Analyzes conventional commits and calculates semantic version progression
 ##
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.12
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -438,7 +438,7 @@ function gitsv:is_tag_included() {
 ## @return tag name (without 'v' prefix) or empty string
 function gitsv:get_last_version_tag() {
   # Get all tags matching semver pattern, sorted by version (descending for efficiency)
-  local tags=$(git tag -l 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -Vr)
+  local tags=$(git tag -l --sort=-version:refname 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+')
 
   # Find the first (highest version) tag that passes ancestry check
   while IFS= read -r tag; do
@@ -458,7 +458,7 @@ function gitsv:get_last_version_tag() {
 ## @return commit hash or empty string
 function gitsv:get_last_version_tag_commit() {
   # Get all tags matching semver pattern, sorted by version (descending for efficiency)
-  local tags=$(git tag -l 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -Vr)
+  local tags=$(git tag -l --sort=-version:refname 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+')
 
   # Find the first (highest version) tag that passes ancestry check
   while IFS= read -r tag; do
@@ -503,7 +503,7 @@ function gitsv:get_commit_from_n_versions_back() {
   local n="$1"
 
   # Get all version tags sorted
-  local all_tags=$(git tag -l 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+' | sort -V)
+  local all_tags=$(git tag -l --sort=version:refname 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+')
 
   # Explicitly check for empty tag list
   if [[ -z "$all_tags" ]]; then

--- a/bin/git.semantic-version.sh
+++ b/bin/git.semantic-version.sh
@@ -19,11 +19,7 @@ export SKIP_ARGS_PARSING=1
 
 # Bootstrap: 1) E_BASH discovery (only if not set), 2) gnubin setup (always)
 [ "$E_BASH" ] || { _src=${BASH_SOURCE:-$0}; E_BASH=$(cd "${_src%/*}/../.scripts" 2>&- && pwd || echo ~/.e-bash/.scripts); readonly E_BASH; }
-. "$E_BASH/_gnu.sh"
-# Add gnubin to PATH only if directory exists (for macOS compatibility)
-if [[ -d "$E_BASH/../bin/gnubin" ]]; then
-  PATH="$(cd "$E_BASH/../bin/gnubin" && pwd):$PATH"
-fi
+. "$E_BASH/_gnu.sh"; PATH="$(cd "$E_BASH/../bin/gnubin" 2>&- && pwd):$PATH"
 readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 readonly SCRIPT_VERSION="1.0.0"
 

--- a/bin/git.semantic-version.sh
+++ b/bin/git.semantic-version.sh
@@ -419,7 +419,7 @@ function gitsv:extract_semvers_from_tags() {
 function gitsv:is_tag_included() {
   local tag="$1"
 
-  # If filtering is disabled (--all-tags flag), always include
+  # If filtering is disabled (--all-refs flag), always include
   if [[ "$FILTER_BRANCH_TAGS" != "true" ]]; then
     return 0
   fi

--- a/bin/git.semantic-version.sh
+++ b/bin/git.semantic-version.sh
@@ -19,7 +19,11 @@ export SKIP_ARGS_PARSING=1
 
 # Bootstrap: 1) E_BASH discovery (only if not set), 2) gnubin setup (always)
 [ "$E_BASH" ] || { _src=${BASH_SOURCE:-$0}; E_BASH=$(cd "${_src%/*}/../.scripts" 2>&- && pwd || echo ~/.e-bash/.scripts); readonly E_BASH; }
-. "$E_BASH/_gnu.sh"; PATH="$(cd "$E_BASH/../bin/gnubin" 2>&- && pwd):$PATH"
+. "$E_BASH/_gnu.sh"
+# Add gnubin to PATH only if directory exists (for macOS compatibility)
+if [[ -d "$E_BASH/../bin/gnubin" ]]; then
+  PATH="$(cd "$E_BASH/../bin/gnubin" && pwd):$PATH"
+fi
 readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 readonly SCRIPT_VERSION="1.0.0"
 

--- a/bin/version-up.v2.sh
+++ b/bin/version-up.v2.sh
@@ -3,8 +3,8 @@
 # shellcheck disable=SC2155,SC1090,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.12
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -264,7 +264,7 @@ function use_prefix() {
 
 # get the highest version tag for all branches, print it to STDOUT
 function highest_tag() {
-	local gitTag=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null)
+	local gitTag=$(git tag --list --sort=-version:refname 2>/dev/null | head -n1 2>/dev/null)
 	echo "$gitTag"
 }
 

--- a/demos/demo.args.sh
+++ b/demos/demo.args.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.cache.sh
+++ b/demos/demo.cache.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.dependencies.sh
+++ b/demos/demo.dependencies.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.dryrun-modes.sh
+++ b/demos/demo.dryrun-modes.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.dryrun-v2.sh
+++ b/demos/demo.dryrun-v2.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.dryrun.sh
+++ b/demos/demo.dryrun.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.emojis.sh
+++ b/demos/demo.emojis.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.hooks-logging.sh
+++ b/demos/demo.hooks-logging.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.hooks-nested.sh
+++ b/demos/demo.hooks-nested.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.hooks-registration.sh
+++ b/demos/demo.hooks-registration.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.hooks.sh
+++ b/demos/demo.hooks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.ipv6.sh
+++ b/demos/demo.ipv6.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.logs.sh
+++ b/demos/demo.logs.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.readpswd.sh
+++ b/demos/demo.readpswd.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.selector.sh
+++ b/demos/demo.selector.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.selfupdate.sh
+++ b/demos/demo.selfupdate.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 ##

--- a/demos/demo.semver.sh
+++ b/demos/demo.semver.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.sorting.v2.sh
+++ b/demos/demo.sorting.v2.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155,SC2034,SC2059
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.tmux.exec.sh
+++ b/demos/demo.tmux.exec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.tmux.progress.sh
+++ b/demos/demo.tmux.progress.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.tmux.streams.sh
+++ b/demos/demo.tmux.streams.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/demos/demo.traps.sh
+++ b/demos/demo.traps.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2155
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.2
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 

--- a/spec/git_semantic_version_spec.sh
+++ b/spec/git_semantic_version_spec.sh
@@ -4,8 +4,8 @@
 # shellcheck disable=SC2155,SC2034
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-14
-## Version: 2.0.1
+## Last revisit: 2026-01-15
+## Version: 2.0.14
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -492,7 +492,7 @@ Describe "bin/git.semantic-version.sh /"
             ;;
           "merge-base --is-ancestor")
             # Simulate: tag IS an ancestor
-            return 0
+            exit 0
             ;;
           *)
             command git "$@"
@@ -516,7 +516,7 @@ Describe "bin/git.semantic-version.sh /"
             ;;
           "merge-base --is-ancestor")
             # Simulate: tag is NOT an ancestor
-            return 1
+            exit 1
             ;;
           *)
             command git "$@"
@@ -539,7 +539,7 @@ Describe "bin/git.semantic-version.sh /"
             ;;
           "merge-base --is-ancestor")
             # Simulate: tag is NOT an ancestor
-            return 1
+            exit 1
             ;;
           *)
             command git "$@"
@@ -592,9 +592,9 @@ Describe "bin/git.semantic-version.sh /"
             # v2.0.0 is NOT an ancestor, v1.0.0 IS an ancestor
             # git merge-base --is-ancestor <commit> HEAD -> $1=merge-base, $2=--is-ancestor, $3=<commit>, $4=HEAD
             if [[ "$3" == "notancestor123" ]]; then
-              return 1
+              exit 1
             elif [[ "$3" == "ancestor456" ]]; then
-              return 0
+              exit 0
             else
               command git "$@"
             fi
@@ -627,7 +627,7 @@ Describe "bin/git.semantic-version.sh /"
             ;;
           merge-base)
             # Simulate NOT an ancestor (but filtering is disabled)
-            return 1
+            exit 1
             ;;
           *)
             command git "$@"

--- a/spec/git_semantic_version_spec.sh
+++ b/spec/git_semantic_version_spec.sh
@@ -579,14 +579,16 @@ Describe "bin/git.semantic-version.sh /"
             ;;
           rev-list)
             # Return commit hash for the tag
-            if [[ "$3" == "v2.0.0" ]]; then
+            # git rev-list -n 1 <tag> -> $1=rev-list, $2=-n, $3=1, $4=<tag>
+            if [[ "$4" == "v2.0.0" ]]; then
               echo "notancestor123"
-            elif [[ "$3" == "v1.0.0" ]]; then
+            elif [[ "$4" == "v1.0.0" ]]; then
               echo "ancestor456"
             fi
             ;;
           merge-base)
             # v2.0.0 is NOT an ancestor, v1.0.0 IS an ancestor
+            # git merge-base --is-ancestor <commit> HEAD -> $1=merge-base, $2=--is-ancestor, $3=<commit>, $4=HEAD
             if [[ "$3" == "notancestor123" ]]; then
               return 1
             elif [[ "$3" == "ancestor456" ]]; then

--- a/spec/git_semantic_version_spec.sh
+++ b/spec/git_semantic_version_spec.sh
@@ -495,7 +495,7 @@ Describe "bin/git.semantic-version.sh /"
             return 0
             ;;
           *)
-            %preserve git
+            command git "$@"
             ;;
         esac
       End
@@ -519,7 +519,7 @@ Describe "bin/git.semantic-version.sh /"
             return 1
             ;;
           *)
-            %preserve git
+            command git "$@"
             ;;
         esac
       End
@@ -542,7 +542,7 @@ Describe "bin/git.semantic-version.sh /"
             return 1
             ;;
           *)
-            %preserve git
+            command git "$@"
             ;;
         esac
       End
@@ -584,6 +584,8 @@ Describe "bin/git.semantic-version.sh /"
               echo "notancestor123"
             elif [[ "$4" == "v1.0.0" ]]; then
               echo "ancestor456"
+            else
+              command git "$@"
             fi
             ;;
           merge-base)
@@ -593,10 +595,12 @@ Describe "bin/git.semantic-version.sh /"
               return 1
             elif [[ "$3" == "ancestor456" ]]; then
               return 0
+            else
+              command git "$@"
             fi
             ;;
           *)
-            %preserve git
+            command git "$@"
             ;;
         esac
       End
@@ -626,7 +630,7 @@ Describe "bin/git.semantic-version.sh /"
             return 1
             ;;
           *)
-            %preserve git
+            command git "$@"
             ;;
         esac
       End


### PR DESCRIPTION
By default, the script now only considers version tags that are ancestors of HEAD (i.e., tags on the current branch). This prevents incorrect version calculations when tags exist on divergent/unmerged branches.

New behavior (default):
- Only considers tags in the current branch ancestry
- Prevents using tags from separate/divergent branches
- Ensures version history matches the actual commit history

Old behavior (opt-in via --all-refs):
- Use --all-refs flag to include ALL tags regardless of branch
- Matches release-it's "getLatestTagFromAllRefs" behavior
- Useful when you want to consider tags from all branches

Changes:
- Added FILTER_BRANCH_TAGS global flag (default: true)
- Added gitsv:is_tag_included() helper function
- Modified gitsv:get_last_version_tag() to filter by ancestry
- Modified gitsv:get_last_version_tag_commit() to filter by ancestry
- Modified gitsv:get_commit_from_n_versions_back() to filter by ancestry
- Added --all-refs flag to disable filtering (like release-it)
- Updated help documentation and examples

Fixes issue where v0.5.1 tag was not captured correctly in repositories with tags on branches not merged into main, like mcp-obsidian-via-rest.

Example:
```bash
# Default: only current branch tags
git.semantic-version.sh --from-last-tag

# Old behavior: all tags from any branch
git.semantic-version.sh --from-last-tag --all-refs
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds ancestry filtering to version tag detection in `git.semantic-version.sh`. By default, only tags that are ancestors of HEAD are considered when calculating semantic versions, preventing incorrect version calculations when tags exist on divergent/unmerged branches.

**Key changes:**
- Added `FILTER_BRANCH_TAGS` global flag (defaults to `true`)
- Implemented `gitsv:is_tag_included()` helper to check if a tag's commit is an ancestor of HEAD using `git merge-base --is-ancestor`
- Updated three functions to use ancestry filtering: `gitsv:get_last_version_tag()`, `gitsv:get_last_version_tag_commit()`, and `gitsv:get_commit_from_n_versions_back()`
- Added `--all-refs` CLI flag to disable filtering (matches release-it behavior)
- Updated help documentation with examples

**Issue found:**
- Comment on line 422 references incorrect flag name (`--all-tags` instead of `--all-refs`)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk after fixing the comment typo
- The implementation is solid with proper fallback handling and the logic is straightforward. The ancestry check using `git merge-base --is-ancestor` is the correct approach. However, there's a minor documentation bug (comment references wrong flag name), and the PR lacks test coverage for the new filtering functionality. The change is backwards-compatible via the `--all-refs` opt-out flag.
- No files require special attention beyond fixing the comment on line 422

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| bin/git.semantic-version.sh | Added ancestry filtering for version tags with `--all-refs` opt-out flag; has one comment mismatch bug |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Script as git.semantic-version.sh
    participant Helper as gitsv:is_tag_included()
    participant Git as git commands

    User->>Script: Execute with flags (e.g., --from-last-tag)
    
    alt --all-refs flag present
        Script->>Script: Set FILTER_BRANCH_TAGS=false
    else default
        Script->>Script: FILTER_BRANCH_TAGS=true (default)
    end

    Script->>Script: Call gitsv:get_last_version_tag()
    Script->>Git: git tag -l (get all tags)
    Git-->>Script: List of tags (sorted -Vr)
    
    loop For each tag (highest version first)
        Script->>Helper: gitsv:is_tag_included(tag)
        
        alt FILTER_BRANCH_TAGS == false
            Helper-->>Script: return 0 (include)
        else FILTER_BRANCH_TAGS == true
            Helper->>Git: git rev-list -n 1 tag
            Git-->>Helper: commit hash
            Helper->>Git: git merge-base --is-ancestor commit HEAD
            
            alt Tag is ancestor of HEAD
                Git-->>Helper: success
                Helper-->>Script: return 0 (include)
            else Tag not in ancestry
                Git-->>Helper: failure
                Helper-->>Script: return 1 (exclude)
            end
        end
        
        alt Tag included
            Script->>Script: Return tag (strip 'v' prefix)
            Script-->>User: Latest version tag
        end
    end
    
    Script-->>User: Empty string (no valid tags)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->