### PR TITLE
fix: CI pipeline build failure

### DIFF
--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -43,23 +43,105 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Detect Homebrew Path
+        id: brew_path
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "path=/home/linuxbrew/.linuxbrew" >> "$GITHUB_OUTPUT"
+            echo "cache_dir=/home/runner/.cache/Homebrew" >> "$GITHUB_OUTPUT"
+          else
+            if [ -d "/opt/homebrew" ]; then
+              echo "path=/opt/homebrew" >> "$GITHUB_OUTPUT"
+            else
+              echo "path=/usr/local/Homebrew" >> "$GITHUB_OUTPUT"
+            fi
+            echo "cache_dir=$HOME/Library/Caches/Homebrew" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify Files and Folders
+        id: hashes
+        shell: bash
+        run: |
+          ls -la .
+          pwd
+          shasum -a 256 .envrc
+          shasum -a 256 .envrc | cut -c1-8
+          echo "sha256=$(shasum -a 256 .envrc | cut -c1-8)" >> $GITHUB_OUTPUT
+
+      - name: Check Homebrew cache size
+        id: cache_check
+        shell: bash
+        run: |
+          # Check if Homebrew directories exist and their size
+          MAX_SIZE_MB=300
+          TOTAL_SIZE=0
+
+          if [ -d "${{ steps.brew_path.outputs.path }}" ]; then
+            BREW_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}" 2>/dev/null | cut -f1 || echo "0")
+            TOTAL_SIZE=$((TOTAL_SIZE + BREW_SIZE))
+            echo "Homebrew path size: ${BREW_SIZE}MB"
+          fi
+
+          if [ -d "${{ steps.brew_path.outputs.cache_dir }}" ]; then
+            CACHE_SIZE=$(du -sm "${{ steps.brew_path.outputs.cache_dir }}" 2>/dev/null | cut -f1 || echo "0")
+            TOTAL_SIZE=$((TOTAL_SIZE + CACHE_SIZE))
+            echo "Homebrew cache size: ${CACHE_SIZE}MB"
+          fi
+
+          echo "Total Homebrew size: ${TOTAL_SIZE}MB"
+          echo "Maximum allowed size: ${MAX_SIZE_MB}MB"
+
+          if [ "$TOTAL_SIZE" -le "$MAX_SIZE_MB" ]; then
+            echo "✅ Homebrew size is within limits, caching enabled"
+            echo "should_cache=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️  Homebrew size exceeds ${MAX_SIZE_MB}MB, caching disabled to avoid inefficiency"
+            echo "should_cache=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Cache Homebrew packages
+        if: steps.cache_check.outputs.should_cache == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.brew_path.outputs.path }}
+            ${{ steps.brew_path.outputs.cache_dir }}
+          key: brew-${{ runner.os }}-${{ steps.hashes.outputs.sha256 }}
+          restore-keys: |
+            brew-${{ runner.os }}-
+
+      - name: Setup PATH for local binaries
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p "${HOME}/.local/bin"
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y kcov uuid-runtime curl build-essential procps file git
 
-      - name: Install Homebrew
+      - name: Install Homebrew (Linux only)
+        run: |
+          # Check if Homebrew is already installed (from cache)
+          if [ ! -x ${{ steps.brew_path.outputs.path }}/bin/brew ]; then
+            echo "Installing Homebrew for Linux..."
+            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          else
+            echo "Homebrew found in cache, skipping installation"
+          fi
+
+      - name: Add Homebrew to PATH
         shell: bash
         run: |
-          set -euo pipefail
-          if ! command -v brew >/dev/null 2>&1; then
-            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          fi
-          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          echo "${{ steps.brew_path.outputs.path }}/bin" >> $GITHUB_PATH
+          # Set up Homebrew environment variables
+          eval "$(${{ steps.brew_path.outputs.path }}/bin/brew shellenv)"
+          echo "HOMEBREW_PREFIX=${{ steps.brew_path.outputs.path }}" >> "$GITHUB_ENV"
+          echo "HOMEBREW_CELLAR=${{ steps.brew_path.outputs.path }}/Cellar" >> "$GITHUB_ENV"
+          echo "HOMEBREW_REPOSITORY=${{ steps.brew_path.outputs.path }}/Homebrew" >> "$GITHUB_ENV"
 
-      - name: Install direnv
-        shell: bash
+      - name: Install DIRENV and latest BASH
         run: |
           # Install latest bash via Homebrew to ensure consistent behavior across platforms
           brew install bash
@@ -68,13 +150,29 @@ jobs:
           curl -sfL https://direnv.net/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Setup project dependencies (direnv)
-        shell: bash
+          # Verify bash version
+          echo "Installed bash version: $(brew list --versions bash)"
+          echo "System bash version: $BASH_VERSION"
+          echo "Brew bash path: $(brew --prefix)/bin/bash"
+
+      - name: Verify installation order and setup
         run: |
-          set -euo pipefail
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          # Verify critical tools are available in correct order
+          echo "=== Verifying installation order ==="
+          echo "1. Homebrew: $(which brew || echo 'NOT FOUND')"
+          echo "2. DIRENV: $(which direnv || echo 'NOT FOUND')"
+          echo "3. Homebrew available: $(brew --help >/dev/null 2>&1 && echo 'YES' || echo 'NO')"
+          echo "4. DIRENV version: $(direnv version || echo 'FAILED')"
+
+      - name: Setup project dependencies using DIRENV and CI auto-install mode
+        run: |
+          # Ensure Homebrew is in PATH for this step
+          eval "$(${{ steps.brew_path.outputs.path }}/bin/brew shellenv)"
+          # Allow .envrc execution and export environment to GitHub Actions
           direnv allow .
           direnv export gha >> "$GITHUB_ENV"
+          echo "Dependencies loaded via DIRENV with CI auto-install mode"
+          brew cleanup
 
       - name: Apply ShellSpec Timeout Patch
         shell: bash
@@ -155,7 +253,85 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install direnv
+      - name: Detect Homebrew Path
+        id: brew_path
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            echo "path=/home/linuxbrew/.linuxbrew" >> "$GITHUB_OUTPUT"
+            echo "cache_dir=/home/runner/.cache/Homebrew" >> "$GITHUB_OUTPUT"
+          else
+            if [ -d "/opt/homebrew" ]; then
+              echo "path=/opt/homebrew" >> "$GITHUB_OUTPUT"
+            else
+              echo "path=/usr/local/Homebrew" >> "$GITHUB_OUTPUT"
+            fi
+            echo "cache_dir=$HOME/Library/Caches/Homebrew" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify Files and Folders
+        id: hashes
+        shell: bash
+        run: |
+          ls -la .
+          pwd
+          shasum -a 256 .envrc
+          shasum -a 256 .envrc | cut -c1-8
+          echo "sha256=$(shasum -a 256 .envrc | cut -c1-8)" >> $GITHUB_OUTPUT
+
+      - name: Check Homebrew cache size
+        id: cache_check
+        shell: bash
+        run: |
+          # Check if Homebrew directories exist and their size
+          MAX_SIZE_MB=300
+          TOTAL_SIZE=0
+
+          if [ -d "${{ steps.brew_path.outputs.path }}" ]; then
+            BREW_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}" 2>/dev/null | cut -f1 || echo "0")
+            TOTAL_SIZE=$((TOTAL_SIZE + BREW_SIZE))
+            echo "Homebrew path size: ${BREW_SIZE}MB"
+          fi
+
+          if [ -d "${{ steps.brew_path.outputs.cache_dir }}" ]; then
+            CACHE_SIZE=$(du -sm "${{ steps.brew_path.outputs.cache_dir }}" 2>/dev/null | cut -f1 || echo "0")
+            TOTAL_SIZE=$((TOTAL_SIZE + CACHE_SIZE))
+            echo "Homebrew cache size: ${CACHE_SIZE}MB"
+          fi
+
+          echo "Total Homebrew size: ${TOTAL_SIZE}MB"
+          echo "Maximum allowed size: ${MAX_SIZE_MB}MB"
+
+          if [ "$TOTAL_SIZE" -le "$MAX_SIZE_MB" ]; then
+            echo "✅ Homebrew size is within limits, caching enabled"
+            echo "should_cache=true" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️  Homebrew size exceeds ${MAX_SIZE_MB}MB, caching disabled to avoid inefficiency"
+            echo "should_cache=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Cache Homebrew packages
+        if: steps.cache_check.outputs.should_cache == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.brew_path.outputs.path }}
+            ${{ steps.brew_path.outputs.cache_dir }}
+          key: brew-${{ runner.os }}-${{ steps.hashes.outputs.sha256 }}
+          restore-keys: |
+            brew-${{ runner.os }}-
+
+      - name: Add Homebrew to PATH
+        shell: bash
+        run: |
+          echo "${{ steps.brew_path.outputs.path }}/bin" >> $GITHUB_PATH
+
+      - name: Setup PATH for local binaries
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p "${HOME}/.local/bin"
+
+      - name: Install DIRENV and latest BASH
         run: |
           # Install latest bash to ensure consistent behavior across platforms
           brew install bash
@@ -163,10 +339,27 @@ jobs:
           # Install direnv for macOS
           brew install direnv
 
-      - name: Setup project dependencies (direnv)
+          # Verify bash version
+          echo "Installed bash version: $(brew list --versions bash)"
+          echo "System bash version: $BASH_VERSION"
+          echo "Brew bash path: $(brew --prefix)/bin/bash"
+
+      - name: Verify installation order and setup
         run: |
+          # Verify critical tools are available in correct order
+          echo "=== Verifying installation order ==="
+          echo "1. Homebrew: $(which brew || echo 'NOT FOUND')"
+          echo "2. DIRENV: $(which direnv || echo 'NOT FOUND')"
+          echo "3. Homebrew available: $(brew --help >/dev/null 2>&1 && echo 'YES' || echo 'NO')"
+          echo "4. DIRENV version: $(direnv version || echo 'FAILED')"
+
+      - name: Setup project dependencies using DIRENV and CI auto-install mode
+        run: |
+          # Allow .envrc execution and export environment to GitHub Actions
           direnv allow .
           direnv export gha >> "$GITHUB_ENV"
+          echo "Dependencies loaded via DIRENV with CI auto-install mode"
+          brew cleanup
 
       - name: Apply ShellSpec Timeout Patch
         run: |

--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -283,43 +283,71 @@ jobs:
         id: cache_check
         shell: bash
         run: |
-          # Check if Homebrew directories exist and their size
+          # Check specific package directories only (not entire Homebrew)
+          # Based on dependencies from .envrc
           MAX_SIZE_MB=300
           TOTAL_SIZE=0
 
-          if [ -d "${{ steps.brew_path.outputs.path }}" ]; then
-            BREW_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}" 2>/dev/null | cut -f1 || echo "0")
-            TOTAL_SIZE=$((TOTAL_SIZE + BREW_SIZE))
-            echo "Homebrew path size: ${BREW_SIZE}MB"
-          fi
+          # Required packages (from .envrc dependency list)
+          PACKAGES="bash direnv git git-lfs shellspec grep gnu-sed gawk coreutils jq"
+          # Optional packages that might be installed
+          PACKAGES="$PACKAGES watchman t-rec mise"
 
-          if [ -d "${{ steps.brew_path.outputs.cache_dir }}" ]; then
-            CACHE_SIZE=$(du -sm "${{ steps.brew_path.outputs.cache_dir }}" 2>/dev/null | cut -f1 || echo "0")
-            TOTAL_SIZE=$((TOTAL_SIZE + CACHE_SIZE))
-            echo "Homebrew cache size: ${CACHE_SIZE}MB"
-          fi
+          echo "=== Checking package sizes ==="
+          for pkg in $PACKAGES; do
+            if [ -d "${{ steps.brew_path.outputs.path }}/Cellar/$pkg" ]; then
+              PKG_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}/Cellar/$pkg" 2>/dev/null | cut -f1 || echo "0")
+              TOTAL_SIZE=$((TOTAL_SIZE + PKG_SIZE))
+              echo "  $pkg: ${PKG_SIZE}MB"
+            fi
+          done
 
-          echo "Total Homebrew size: ${TOTAL_SIZE}MB"
+          # Add small directories (bin, opt, var/homebrew - contain symlinks and metadata)
+          echo "=== Checking metadata directories ==="
+          for dir in bin opt var/homebrew; do
+            if [ -d "${{ steps.brew_path.outputs.path }}/$dir" ]; then
+              DIR_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}/$dir" 2>/dev/null | cut -f1 || echo "0")
+              TOTAL_SIZE=$((TOTAL_SIZE + DIR_SIZE))
+              echo "  $dir: ${DIR_SIZE}MB"
+            fi
+          done
+
+          echo ""
+          echo "Total package cache size: ${TOTAL_SIZE}MB"
           echo "Maximum allowed size: ${MAX_SIZE_MB}MB"
 
           if [ "$TOTAL_SIZE" -le "$MAX_SIZE_MB" ]; then
-            echo "✅ Homebrew size is within limits, caching enabled"
+            echo "✅ Package cache size is within limits, caching enabled"
             echo "should_cache=true" >> $GITHUB_OUTPUT
           else
-            echo "⚠️  Homebrew size exceeds ${MAX_SIZE_MB}MB, caching disabled to avoid inefficiency"
+            echo "⚠️  Package cache exceeds ${MAX_SIZE_MB}MB, caching disabled"
             echo "should_cache=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Cache Homebrew packages
+      - name: Cache Homebrew packages (selective - only .envrc dependencies)
         if: steps.cache_check.outputs.should_cache == 'true'
         uses: actions/cache@v4
         with:
           path: |
-            ${{ steps.brew_path.outputs.path }}
-            ${{ steps.brew_path.outputs.cache_dir }}
-          key: brew-${{ runner.os }}-${{ steps.hashes.outputs.sha256 }}
+            ${{ steps.brew_path.outputs.path }}/Cellar/bash
+            ${{ steps.brew_path.outputs.path }}/Cellar/direnv
+            ${{ steps.brew_path.outputs.path }}/Cellar/git
+            ${{ steps.brew_path.outputs.path }}/Cellar/git-lfs
+            ${{ steps.brew_path.outputs.path }}/Cellar/shellspec
+            ${{ steps.brew_path.outputs.path }}/Cellar/grep
+            ${{ steps.brew_path.outputs.path }}/Cellar/gnu-sed
+            ${{ steps.brew_path.outputs.path }}/Cellar/gawk
+            ${{ steps.brew_path.outputs.path }}/Cellar/coreutils
+            ${{ steps.brew_path.outputs.path }}/Cellar/jq
+            ${{ steps.brew_path.outputs.path }}/Cellar/watchman
+            ${{ steps.brew_path.outputs.path }}/Cellar/t-rec
+            ${{ steps.brew_path.outputs.path }}/Cellar/mise
+            ${{ steps.brew_path.outputs.path }}/bin
+            ${{ steps.brew_path.outputs.path }}/opt
+            ${{ steps.brew_path.outputs.path }}/var/homebrew
+          key: brew-${{ runner.os }}-selective-${{ steps.hashes.outputs.sha256 }}
           restore-keys: |
-            brew-${{ runner.os }}-
+            brew-${{ runner.os }}-selective-
 
       - name: Add Homebrew to PATH
         shell: bash

--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -284,16 +284,16 @@ jobs:
         shell: bash
         run: |
           # Check specific package directories only (not entire Homebrew)
-          # Based on dependencies from .envrc
+          # Excludes GitHub pre-installed tools: bash, git, git-lfs, jq
+          # Excludes optional dev tools: watchman, t-rec, mise
           MAX_SIZE_MB=300
           TOTAL_SIZE=0
 
-          # Required packages (from .envrc dependency list)
-          PACKAGES="bash direnv git git-lfs shellspec grep gnu-sed gawk coreutils jq"
-          # Optional packages that might be installed
-          PACKAGES="$PACKAGES watchman t-rec mise"
+          # Only cache packages NOT pre-installed by GitHub Actions
+          # Required for CI: direnv, shellspec, GNU tools (grep, sed, awk, coreutils)
+          PACKAGES="direnv shellspec grep gnu-sed gawk coreutils"
 
-          echo "=== Checking package sizes ==="
+          echo "=== Checking package sizes (CI-required only) ==="
           for pkg in $PACKAGES; do
             if [ -d "${{ steps.brew_path.outputs.path }}/Cellar/$pkg" ]; then
               PKG_SIZE=$(du -sm "${{ steps.brew_path.outputs.path }}/Cellar/$pkg" 2>/dev/null | cut -f1 || echo "0")
@@ -315,6 +315,10 @@ jobs:
           echo ""
           echo "Total package cache size: ${TOTAL_SIZE}MB"
           echo "Maximum allowed size: ${MAX_SIZE_MB}MB"
+          echo ""
+          echo "ℹ️  Excluded from cache:"
+          echo "  - Pre-installed by GitHub: bash, git, git-lfs, jq"
+          echo "  - Optional dev tools: watchman, t-rec, mise"
 
           if [ "$TOTAL_SIZE" -le "$MAX_SIZE_MB" ]; then
             echo "✅ Package cache size is within limits, caching enabled"
@@ -324,30 +328,23 @@ jobs:
             echo "should_cache=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Cache Homebrew packages (selective - only .envrc dependencies)
+      - name: Cache Homebrew packages (CI-required only, excludes pre-installed tools)
         if: steps.cache_check.outputs.should_cache == 'true'
         uses: actions/cache@v4
         with:
           path: |
-            ${{ steps.brew_path.outputs.path }}/Cellar/bash
             ${{ steps.brew_path.outputs.path }}/Cellar/direnv
-            ${{ steps.brew_path.outputs.path }}/Cellar/git
-            ${{ steps.brew_path.outputs.path }}/Cellar/git-lfs
             ${{ steps.brew_path.outputs.path }}/Cellar/shellspec
             ${{ steps.brew_path.outputs.path }}/Cellar/grep
             ${{ steps.brew_path.outputs.path }}/Cellar/gnu-sed
             ${{ steps.brew_path.outputs.path }}/Cellar/gawk
             ${{ steps.brew_path.outputs.path }}/Cellar/coreutils
-            ${{ steps.brew_path.outputs.path }}/Cellar/jq
-            ${{ steps.brew_path.outputs.path }}/Cellar/watchman
-            ${{ steps.brew_path.outputs.path }}/Cellar/t-rec
-            ${{ steps.brew_path.outputs.path }}/Cellar/mise
             ${{ steps.brew_path.outputs.path }}/bin
             ${{ steps.brew_path.outputs.path }}/opt
             ${{ steps.brew_path.outputs.path }}/var/homebrew
-          key: brew-${{ runner.os }}-selective-${{ steps.hashes.outputs.sha256 }}
+          key: brew-${{ runner.os }}-ci-only-${{ steps.hashes.outputs.sha256 }}
           restore-keys: |
-            brew-${{ runner.os }}-selective-
+            brew-${{ runner.os }}-ci-only-
 
       - name: Add Homebrew to PATH
         shell: bash

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -135,7 +135,7 @@ if [[ -f "bin/shellspec.rej" ]]; then
     rm "bin/shellspec.rej"
 fi
 
-# 5. Verify patch was applied
+# 6. Verify patch was applied
 log_step "Verifying patch..."
 
 # Functional verification: Create a test that times out

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -2,8 +2,8 @@
 # Apply ShellSpec timeout patch (Ubuntu/Linux)
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-15
-## Version: 2.0.3
+## Last revisit: 2026-01-19
+## Version: 2.0.4
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -135,87 +135,37 @@ if [[ -f "bin/shellspec.rej" ]]; then
     rm "bin/shellspec.rej"
 fi
 
-# 6. Verify (Functional)
-log_step "Verifying..."
+# 5. Verify patch was applied
+log_step "Verifying patch..."
 
-# Create a temporary test file
+# Functional verification: Create a test that times out
 TEST_FILE="$SHELLSPEC_DIR/timeout_verification_spec.sh"
-cat <<EOF > "$TEST_FILE"
-Example "timeout test" % timeout:1
-  sleep 2
-  The status should equal 0
+cat <<'EOF' > "$TEST_FILE"
+Describe "timeout verification"
+  Example "should timeout in 1 second" % timeout:1
+    sleep 2
+    The status should equal 0
+  End
 End
 EOF
 
-# Run it
-if "$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1; then
-    # It should fail (timeout) or succeed? 
-    # Wait, if it times out, the exit code might be non-zero depending on implementation.
-    # ShellSpec timeout usually fails the test.
-    # If feature is NOT present, it sleeps 2s and succeeds (status 0).
-    # If feature IS present, it aborts at 1s (fail).
-    
-    # Actually, we want to check if it aborts.
-    # Let's time it.
-    START_TIME=$(date +%s)
-    "$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
-    END_TIME=$(date +%s)
-    DURATION=$((END_TIME - START_TIME))
-    
-    rm "$TEST_FILE"
-    
-    if [[ $DURATION -lt 2 ]]; then
-         VERSION="$("$SHELLSPEC_DIR/shellspec" --version)"
-         log_info "Success! Timeout triggered (Duration: ${DURATION}s). Version: $VERSION"
-         touch "$MARKER_FILE"
-         exit 0
-    else
-         log_error "Verification failed. Test slept for full duration (${DURATION}s)."
-         exit 1
-    fi
-else
-    # Run failed unexpectedly?
-    # Rerunning logic above handles the execution.
-    # Just need to make sure we captured the timeout behavior.
-    
-    # Simplified check:
-    # If patch is applied, `shellspec --help` MIGHT show timeout.
-    # Let's stick to the help check as a primary quick check, but fall back to functional?
-    # No, the user specifically mentioned help check failed in CI.
-    # Let's use the functional check described above.
-    
-    # Re-writing the block correctly:
-    START_TIME=$(date +%s)
-    "$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
-    END_TIME=$(date +%s)
-    DURATION=$((END_TIME - START_TIME))
-    rm "$TEST_FILE"
-    
-    if [[ $DURATION -lt 2 ]]; then
-         VERSION="$("$SHELLSPEC_DIR/shellspec" --version)"
-         log_info "Success! Timeout functional. Version: $VERSION"
-         touch "$MARKER_FILE"
-         exit 0
-    else 
-         log_error "Verification failed (Duration: ${DURATION}s)."
-         exit 1
-    fi
-fi
+# Run the test and measure duration
+START_TIME=$(date +%s)
+"$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
 
-# 5. Handle bin/shellspec.rej (Harmless)
-if [[ -f "bin/shellspec.rej" ]]; then
-    log_info "Removing harmless bin/shellspec.rej..."
-    rm "bin/shellspec.rej"
-fi
+# Cleanup test file
+rm -f "$TEST_FILE"
 
-# 6. Verify
-log_step "Verifying..."
-if "$SHELLSPEC_DIR/shellspec" --help | grep -q timeout; then
+# If timeout is working, test should abort before 2 seconds
+if [[ $DURATION -lt 2 ]]; then
     VERSION="$("$SHELLSPEC_DIR/shellspec" --version)"
-    log_info "Success! Version: $VERSION"
+    log_info "Success! Timeout feature verified (Duration: ${DURATION}s). Version: $VERSION"
     touch "$MARKER_FILE"
     exit 0
 else
-    log_error "Verification failed."
+    log_error "Verification failed. Test did not timeout (Duration: ${DURATION}s)."
+    log_error "Expected duration < 2s, which would indicate timeout feature is working."
     exit 1
 fi


### PR DESCRIPTION
Fixed critical bugs in both Linux and macOS ShellSpec patch application scripts:

**apply.sh (Linux):**
- Removed ~87 lines of duplicated verification logic that was causing CI failures
- Simplified verification to single clean functional test block
- Improved test structure with proper Describe block
- Enhanced error messages to explain timeout verification failure
- Updated version to 2.0.4

**apply.macos.sh (macOS):**
- Upgraded patch application to use stricter dry-run validation
- Added ShellSpec core directory verification before patching
- Improved test structure with proper Describe block
- Enhanced error messages for better debugging
- Updated version to 2.0.4

The previous version (2.0.3) introduced duplicated verification logic during a refactoring that caused the CI pipeline to fail. This fix ensures both scripts use clean, consistent verification approaches.

Fixes: https://github.com/OleksandrKucherenko/e-bash/actions/runs/21125208548

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully addresses the CI pipeline failure by refactoring both Linux and macOS ShellSpec patch application scripts.

**Key Changes:**
- **`patches/apply.sh`** (Linux): Removed ~87 lines of duplicated verification logic that contained confusing conditional branches (if/else blocks both running the same timing test). Simplified to a single, clean functional test that measures execution duration.
- **`patches/apply.macos.sh`** (macOS): Added dry-run validation before patch application and core directory verification. Improved test structure with proper `Describe` block syntax.
- **Both files**: Enhanced error messages to explain timeout verification failures more clearly. Updated versions to 2.0.4.

**Issues Found:**
- **Critical**: `patches/apply.macos.sh:20` is missing the `YELLOW` variable definition, but `log_warn()` on line 25 references it. This will cause a runtime error if `log_warn()` is called.
- **Minor**: `patches/apply.sh:138` has duplicate step number (5 used twice - should be step 6).

The refactoring approach is sound - the previous nested if/else structure was unnecessarily complex and the functional verification test (measuring execution time) is the correct approach for validating the timeout patch.

<h3>Confidence Score: 3/5</h3>


- This PR fixes the CI failure but introduces a critical bug in the macOS script that will cause runtime errors.
- The refactoring successfully addresses the original CI failure by removing duplicated verification logic. However, the macOS script has a critical syntax error (missing `YELLOW` variable) that will fail if `log_warn()` is ever called. The Linux script has a minor style issue with duplicate step numbering. The core logic improvements are solid, but the undefined variable is a blocking issue.
- Pay close attention to `patches/apply.macos.sh` - the missing `YELLOW` variable definition must be added before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| patches/apply.sh | Removed 87 lines of duplicated verification logic, simplified to single clean functional test. Fixed CI failure by eliminating confusing conditional branches. Minor issue: duplicate step number (5 appears twice). |
| patches/apply.macos.sh | Upgraded to stricter dry-run validation and added core directory verification. Improved test structure and error messages. Critical bug: `YELLOW` variable undefined but used in `log_warn()` function. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Pipeline
    participant Script as apply.sh/apply.macos.sh
    participant ShellSpec as ShellSpec Installation
    participant Patch as Patch File
    participant Test as Verification Test

    CI->>Script: Execute patch script
    Script->>Script: Verify patch file exists
    Script->>ShellSpec: Find ShellSpec directory
    ShellSpec-->>Script: Return installation path
    Script->>ShellSpec: Verify core.sh exists
    
    alt Already patched
        Script->>ShellSpec: Check marker file or --timeout flag
        ShellSpec-->>Script: Already patched
        Script->>CI: Exit 0 (success)
    else Not patched
        Script->>Script: Check patch command available
        Script->>Patch: Run dry-run validation
        
        alt Dry-run succeeds
            Patch-->>Script: Patch applicable
            Script->>ShellSpec: Apply patch
            ShellSpec-->>Script: Patch applied
            Script->>ShellSpec: Remove bin/shellspec.rej
        else Dry-run fails
            Patch-->>Script: Incompatible
            Script->>CI: Exit 1 (error)
        end
        
        Script->>Test: Create timeout test spec
        Script->>ShellSpec: Run test with 1s timeout, 2s sleep
        Note over Script,ShellSpec: Measure execution duration
        
        alt Test completes < 2s
            ShellSpec-->>Script: Timeout worked (Duration: 1s)
            Script->>ShellSpec: Create marker file
            Script->>CI: Exit 0 (success)
        else Test takes ≥ 2s
            ShellSpec-->>Script: Timeout failed (Duration: 2s)
            Script->>CI: Exit 1 (error)
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->