### PR TITLE
feat: cleanup and minor changes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,11 +25,7 @@ coverage:
 # Flag configuration for parallel uploads
 flags:
   shellspec-ubuntu:
-    # All 4 chunks upload with this flag
-    carryforward: true
-
-  shellspec-macos:
-    # MacOS chunks (if applicable)
+    # All 4 ubuntu chunks upload with this flag and are merged via parallel: true
     carryforward: true
 
 # Comment configuration for PRs

--- a/.envrc
+++ b/.envrc
@@ -1,12 +1,6 @@
 # shellcheck disable=SC2148,SC2155
 
 #
-# Setup Git hooks from .githook directory
-#
-[ -d ".git" ] && git config core.hooksPath .githook
-[ -d ".githook" ] && chmod +x .githook/*
-
-#
 # on terminal bootstrap .zshrc loading takes time, and path to tools can be not yet available
 # so we need to add path to tools to PATH variable to prevent false fails
 #
@@ -116,14 +110,10 @@ fi
 #
 # Install lefthook as primary hooks
 if command -v lefthook >/dev/null 2>&1; then
-  lefthook install 2>/dev/null || true
   # Reset hooksPath to default (lefthook manages hooks in .git/hooks)
-  git config --unset core.hooksPath 2>/dev/null || true
-else
-  echo "⚠️  lefthook not found. Install with: brew install lefthook"
-  echo "   Falling back to legacy hooks..."
-  [ -d ".git" ] && git config core.hooksPath .githook
-  [ -d ".githook" ] && chmod +x .githook/*
+  # git config --unset core.hooksPath 2>/dev/null || true
+  # and now install lefthook
+  lefthook install 2>/dev/null || true
 fi
 
 cl:unset

--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -492,7 +492,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           # Try directory mode first, then fall back to file mode
           directory: ./coverage
@@ -503,6 +503,8 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           disable_search: false
+          # Mark as parallel upload - chunks will be merged after all complete
+          parallel: true
           # Ensure proper merging of parallel uploads
           override_branch: ${{ github.ref_name }}
           override_commit: ${{ github.sha }}
@@ -532,6 +534,21 @@ jobs:
           path: report/
           if-no-files-found: ignore
           retention-days: 30
+
+  codecov-merge:
+    name: "Codecov Merge"
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    needs: shellspec-ubuntu
+    steps:
+      - name: Finalize Codecov merge
+        uses: codecov/codecov-action@v5
+        with:
+          parallel_finished: true
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   shellmetrics:
     name: "Code Metrics"

--- a/.github/workflows/shellspec.yaml
+++ b/.github/workflows/shellspec.yaml
@@ -494,17 +494,15 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v5
         with:
-          # Try directory mode first, then fall back to file mode
+          # Search directory for coverage files (supports cobertura.xml, coverage.json, etc.)
           directory: ./coverage
-          files: ./coverage/cobertura.xml
-          # Use consistent flag for all chunks to enable merging
+          # Use consistent flag for all chunks - Codecov v5 auto-merges by flag
           flags: shellspec-ubuntu
           name: ubuntu-chunk-${{ matrix.chunk }}
           fail_ci_if_error: false
           verbose: true
+          # Don't specify files - let Codecov auto-discover in the directory
           disable_search: false
-          # Mark as parallel upload - chunks will be merged after all complete
-          parallel: true
           # Ensure proper merging of parallel uploads
           override_branch: ${{ github.ref_name }}
           override_commit: ${{ github.sha }}
@@ -522,9 +520,13 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results as artifact
         if: always()
@@ -534,21 +536,6 @@ jobs:
           path: report/
           if-no-files-found: ignore
           retention-days: 30
-
-  codecov-merge:
-    name: "Codecov Merge"
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
-    needs: shellspec-ubuntu
-    steps:
-      - name: Finalize Codecov merge
-        uses: codecov/codecov-action@v5
-        with:
-          parallel_finished: true
-          fail_ci_if_error: false
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   shellmetrics:
     name: "Code Metrics"

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -10,9 +10,6 @@ pre-commit:
   # (can be enabled to true after validation)
   parallel: false
 
-  # Skip in CI by default
-  skip_on_ci: true
-
   jobs:
     # Job 1: Verify and add copyright notices
     - name: copyright-verification
@@ -39,8 +36,7 @@ pre-commit:
       script: "edocs-update.sh"
       runner: bash
       glob: ".scripts/*.sh"
-      # Don't fail if docs generation fails
-      run_on_failure: true
+
       tags: [docs, automation]
 
 # Optional: Commit message validation (for future use)


### PR DESCRIPTION
Upgrade Codecov action to v5 with parallel uploads, remove legacy Git hook management, and enable Lefthook in CI.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR modernizes the CI/CD infrastructure by upgrading to Codecov v5, implementing proper parallel coverage uploads, and completing the migration from legacy Git hooks to Lefthook.

**Key Changes:**
- Upgraded `codecov-action` from v4 to v5 with parallel upload support for Ubuntu test chunks
- Added `codecov-merge` job to properly finalize parallel coverage uploads after all chunks complete
- Removed legacy `.githook` directory management from `.envrc`, fully migrating to Lefthook
- Enabled Lefthook hooks in CI by removing `skip_on_ci: true` from `.lefthook.yml`
- Consolidated coverage reporting to Ubuntu-only (removed `shellspec-macos` flag from `.codecov.yml`)
- Removed `run_on_failure: true` from edocs-update hook for clearer failure handling

**Integration Impact:**
The changes align with Codecov v5's improved parallel upload mechanism, where each Ubuntu chunk uploads with `parallel: true` and a dedicated merge job sends `parallel_finished: true` to trigger coverage report generation. This ensures accurate coverage merging across test chunks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are infrastructure improvements with clear intent: upgrading to Codecov v5 follows documented migration patterns, parallel upload configuration is correctly implemented with proper merge job, and the Lefthook migration removes legacy code without introducing new dependencies. No logic changes to core functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .codecov.yml | Removed `shellspec-macos` flag configuration to consolidate coverage reporting to Ubuntu only, aligning with new parallel upload strategy |
| .envrc | Removed legacy Git hook management code, simplified Lefthook installation to rely on standard `.git/hooks` directory |
| .github/workflows/shellspec.yaml | Upgraded Codecov action to v5, added `parallel: true` for Ubuntu chunks, created `codecov-merge` job to finalize parallel uploads |
| .lefthook.yml | Enabled Lefthook in CI by removing `skip_on_ci: true`, removed `run_on_failure: true` from edocs-update job |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Env as .envrc
    participant LH as Lefthook
    participant GH as GitHub Actions
    participant CC as Codecov

    Note over Dev,LH: Local Development Setup
    Dev->>Env: direnv allow
    Env->>Env: Remove legacy .githook setup
    Env->>LH: lefthook install
    LH->>LH: Configure hooks in .git/hooks
    Note over LH: skip_on_ci removed<br/>Now runs in CI too

    Note over GH,CC: CI Pipeline Execution
    GH->>GH: Run shellspec-ubuntu (4 chunks)
    loop Each Ubuntu chunk (0-3)
        GH->>GH: Run tests with coverage
        GH->>CC: Upload coverage (parallel: true, flag: shellspec-ubuntu)
        Note over CC: Holds uploads for merge
    end
    
    GH->>GH: All Ubuntu chunks complete
    GH->>GH: Trigger codecov-merge job
    GH->>CC: Send parallel_finished: true
    CC->>CC: Merge all Ubuntu chunk uploads
    CC->>GH: Post coverage report to PR

    Note over GH: macOS chunks excluded<br/>from coverage uploads
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->