### PR TITLE
Add demo curl completion PoC with Bash/Zsh completion and docs; remove old arguments-completion outputs

### DIFF
--- a/demos/demo.curl.bash
+++ b/demos/demo.curl.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Bash completion for demo.curl.sh
+# Usage (bash):
+#   source demos/demo.curl.bash
+#   complete -p demo-curl
+
+__demo_curl_loaded=""
+__demo_curl_flags=()
+__demo_curl_value_flags=()
+__demo_curl_commands=()
+__demo_curl_request_enum=()
+
+__demo_curl_load_data() {
+  local data_line="" data_file="" script_dir=""
+
+  [[ -n "$__demo_curl_loaded" ]] && return 0
+
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>&- && pwd)
+  data_file="${script_dir}/demo.curl.sh"
+
+  while IFS= read -r data_line; do
+    case "$data_line" in
+      FLAGS=*)
+        IFS=' ' read -r -a __demo_curl_flags <<< "${data_line#FLAGS=}"
+        ;;
+      VALUE_FLAGS=*)
+        IFS=' ' read -r -a __demo_curl_value_flags <<< "${data_line#VALUE_FLAGS=}"
+        ;;
+      COMMANDS=*)
+        IFS=' ' read -r -a __demo_curl_commands <<< "${data_line#COMMANDS=}"
+        ;;
+      REQUEST_ENUM=*)
+        IFS=' ' read -r -a __demo_curl_request_enum <<< "${data_line#REQUEST_ENUM=}"
+        ;;
+    esac
+  done < <("$data_file" --completion-data)
+
+  __demo_curl_loaded=1
+}
+
+_demo_curl_complete() {
+  local cur="" prev="" words=() cword=0
+
+  if declare -F _init_completion >/dev/null 2>&1; then
+    _init_completion -n : || return
+  else
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+  fi
+
+  __demo_curl_load_data
+
+  if [[ " ${__demo_curl_value_flags[*]} " == *" ${prev} "* ]]; then
+    if [[ "$prev" == "--request" || "$prev" == "-X" ]]; then
+      COMPREPLY=( $(compgen -W "${__demo_curl_request_enum[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -f -- "$cur") )
+    return 0
+  fi
+
+  if [[ "$cur" == -* ]]; then
+    COMPREPLY=( $(compgen -W "${__demo_curl_flags[*]}" -- "$cur") )
+    return 0
+  fi
+
+  if [[ ${COMP_CWORD} -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "${__demo_curl_commands[*]}" -- "$cur") )
+  fi
+}
+
+complete -F _demo_curl_complete demo-curl

--- a/demos/demo.curl.completion.md
+++ b/demos/demo.curl.completion.md
@@ -1,0 +1,45 @@
+# Demo curl completion PoC
+
+This PoC demonstrates Bash and Zsh completion driven by `ARGS_DEFINITION` metadata from `_arguments.sh`.
+
+## Commands
+
+The mock CLI accepts subcommands:
+
+- `get`, `post`, `head`, `put`, `delete`
+
+## Flags
+
+- `-h, --help`
+- `-X, --request` (enum: `GET POST PUT DELETE HEAD`)
+- `-H, --header`
+- `-d, --data`
+- `--url`
+- `-v, --verbose`
+
+## Easiest vs Elegant integration
+
+### Easiest (separate shell implementations)
+- Bash and Zsh each maintain their own completion glue.
+- Use a single metadata source (`_arguments.sh`) but keep shell-specific adapters.
+- Faster to implement and test; minimal abstraction.
+
+### Most elegant (shared spec + thin adapters)
+- Define a shared completion spec from `_arguments.sh` metadata.
+- Use a small Bash/Zsh adapter to interpret the spec.
+- Requires extra scaffolding, but keeps behavior consistent across shells.
+
+## Bash usage
+
+```bash
+alias demo-curl="$(pwd)/demos/demo.curl.sh"
+source demos/demo.curl.bash
+```
+
+## Zsh usage
+
+```zsh
+alias demo-curl="$(pwd)/demos/demo.curl.sh"
+fpath=("$(pwd)/demos" $fpath)
+autoload -U compinit && compinit
+```

--- a/demos/demo.curl.sh
+++ b/demos/demo.curl.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2026-01-31
+## Version: 0.1.0
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+export DEBUG=${DEBUG:-"demo-curl,-loader,-parser,-common"}
+
+# Bootstrap: 1) E_BASH discovery (only if not set), 2) gnubin setup (always)
+[ "$E_BASH" ] || {
+  _src=${BASH_SOURCE:-$0}
+  E_BASH=$(cd "${_src%/*}/../.scripts" 2>&- && pwd || echo ~/.e-bash/.scripts)
+  readonly E_BASH
+}
+
+# shellcheck disable=SC1090 source=../.scripts/_arguments.sh
+source "$E_BASH/_arguments.sh"
+
+export SKIP_ARGS_PARSING=1
+
+# pre-declare variables to make shellcheck happy
+declare help request header data url verbose args_command
+
+ARGS_DEFINITION=""
+ARGS_DEFINITION+=" -h,--help"
+ARGS_DEFINITION+=" -X,--request=request::1"
+ARGS_DEFINITION+=" -H,--header=header::1"
+ARGS_DEFINITION+=" -d,--data=data::1"
+ARGS_DEFINITION+=" --url=url::1"
+ARGS_DEFINITION+=" -v,--verbose"
+ARGS_DEFINITION+=" \$1,<command>=args_command:dummy:1"
+
+function demo:completion:emit() {
+  local args_qt="" flag="" idx="" keys="" key=""
+  local -a flags=() value_flags=() commands=() request_enum=()
+
+  parse:mapping
+
+  for flag in "${!lookup_arguments[@]}"; do
+    [[ "$flag" == \$* ]] && continue
+    flags+=("$flag")
+  done
+
+  for idx in "${!index_to_args_qt[@]}"; do
+    args_qt="${index_to_args_qt[$idx]}"
+    [[ "$args_qt" -gt 0 ]] || continue
+    keys="${index_to_keys[$idx]}"
+    for key in $keys; do
+      value_flags+=("$key")
+    done
+  done
+
+  IFS=$'\n' flags=($(printf '%s\n' "${flags[@]}" | sort -u))
+  IFS=$'\n' value_flags=($(printf '%s\n' "${value_flags[@]}" | sort -u))
+
+  commands=(get post head put delete)
+  request_enum=(GET POST PUT DELETE HEAD)
+
+  echo "FLAGS=${flags[*]}"
+  echo "VALUE_FLAGS=${value_flags[*]}"
+  echo "COMMANDS=${commands[*]}"
+  echo "REQUEST_ENUM=${request_enum[*]}"
+}
+
+if [[ "$1" == "--completion-data" ]]; then
+  demo:completion:emit
+  exit 0
+fi
+
+parse:arguments "$@"
+
+# register commands and flags for help output
+args:d "\$1" "HTTP subcommand (get/post/head/put/delete)." "commands" 1
+
+args:d "-h" "Show help and exit." "global"
+args:d "-X" "HTTP method (overrides subcommand)." "global"
+args:d "-H" "Add request header." "global"
+args:d "-d" "Request body data." "global"
+args:d "--url" "Request URL (optional if positional URL used)." "global"
+args:d "-v" "Enable verbose output." "global"
+
+args:v "-X" "GET"
+
+if [[ "$help" == "1" ]]; then
+  echo "demo.curl.sh - mock curl-like CLI for completion testing"
+  echo ""
+  echo "Usage: demos/demo.curl.sh [global flags] <command> [flags]"
+  echo ""
+  print:help
+  exit 0
+fi
+
+cat <<OUTPUT
+Demo curl-like command
+  command: ${args_command}
+  request: ${request}
+  header:  ${header}
+  data:    ${data}
+  url:     ${url}
+  verbose: ${verbose}
+OUTPUT
+
+cat <<'SAMPLES'
+Samples:
+  demos/demo.curl.sh get --url https://example.test
+  demos/demo.curl.sh post -X POST -d '{"a":1}' --url https://example.test
+  demos/demo.curl.sh head -H 'Accept: */*' --url https://example.test
+
+Completion data:
+  demos/demo.curl.sh --completion-data
+SAMPLES

--- a/demos/demo.curl.zsh
+++ b/demos/demo.curl.zsh
@@ -1,0 +1,71 @@
+#compdef demo-curl
+
+# Zsh completion for demo.curl.sh
+# Usage (zsh):
+#   fpath=("${0:A:h}" $fpath)
+#   autoload -U compinit && compinit
+
+__demo_curl_loaded=""
+__demo_curl_flags=()
+__demo_curl_value_flags=()
+__demo_curl_commands=()
+__demo_curl_request_enum=()
+
+__demo_curl_load_data() {
+  local data_line="" data_file="" script_dir=""
+
+  [[ -n "$__demo_curl_loaded" ]] && return 0
+
+  script_dir="${0:A:h}"
+  data_file="${script_dir}/demo.curl.sh"
+
+  while IFS= read -r data_line; do
+    case "$data_line" in
+      FLAGS=*)
+        __demo_curl_flags=(${(s: :)${data_line#FLAGS=}})
+        ;;
+      VALUE_FLAGS=*)
+        __demo_curl_value_flags=(${(s: :)${data_line#VALUE_FLAGS=}})
+        ;;
+      COMMANDS=*)
+        __demo_curl_commands=(${(s: :)${data_line#COMMANDS=}})
+        ;;
+      REQUEST_ENUM=*)
+        __demo_curl_request_enum=(${(s: :)${data_line#REQUEST_ENUM=}})
+        ;;
+    esac
+  done < <("$data_file" --completion-data)
+
+  __demo_curl_loaded=1
+}
+
+_demo_curl_complete() {
+  local cur="" prev=""
+
+  setopt local_options no_aliases
+
+  cur="${words[CURRENT]}"
+  prev="${words[CURRENT-1]}"
+
+  __demo_curl_load_data
+
+  if [[ " ${__demo_curl_value_flags[*]} " == *" ${prev} "* ]]; then
+    if [[ "$prev" == "--request" || "$prev" == "-X" ]]; then
+      compadd -- "${__demo_curl_request_enum[@]}"
+      return 0
+    fi
+    _files
+    return 0
+  fi
+
+  if [[ "$cur" == -* ]]; then
+    compadd -- "${__demo_curl_flags[@]}"
+    return 0
+  fi
+
+  if [[ $CURRENT -eq 2 ]]; then
+    compadd -- "${__demo_curl_commands[@]}"
+  fi
+}
+
+compdef _demo_curl_complete demo-curl


### PR DESCRIPTION
### Motivation
- Provide a small proof-of-concept showing how `ARGS_DEFINITION` metadata can drive shell completions by exposing completion data from a CLI script. 
- Replace the previous `.clavix/outputs/arguments-completion` artifacts with an explicit demo that surface the completion metadata and adapters for Bash/Zsh.

### Description
- Add `demos/demo.curl.sh`, a mock curl-like CLI that exposes completion metadata via `--completion-data` and uses existing `_arguments.sh` helpers (`parse:mapping`/`parse:arguments`).
- Add `demos/demo.curl.bash` and `demos/demo.curl.zsh` completion PoC scripts that load the demo script's metadata and provide completions for flags, value-accepting flags, commands, and enum values.
- Add `demos/demo.curl.completion.md` documenting the PoC, usage notes, and two integration approaches (simple shell adapters vs shared spec + adapters).
- Remove `.clavix/outputs/arguments-completion` artifacts (`mini-prd.md`, `original-prompt.md`, `optimized-prompt.md`) as part of cleanup.

### Testing
- No automated tests were run for these demo-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6985c9334b2c832b927cec00b5206a14)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a proof-of-concept demonstrating shell completion driven by `ARGS_DEFINITION` metadata from the `_arguments.sh` module.

**What changed:**
- Added `demos/demo.curl.sh`: Mock curl-like CLI that exposes completion metadata via `--completion-data` flag, using `parse:mapping` to extract flags, value-accepting flags, commands, and enums from `ARGS_DEFINITION`
- Added `demos/demo.curl.bash` and `demos/demo.curl.zsh`: Shell-specific completion adapters that load metadata on-demand and provide context-aware completions
- Added `demos/demo.curl.completion.md`: Documentation explaining the PoC architecture and two integration approaches (simple shell adapters vs shared spec + adapters)

**How it works:**
The completion system uses a data-driven approach where the CLI script exposes structured completion metadata by parsing its own `ARGS_DEFINITION`. Shell completion adapters load this data lazily and use it to provide intelligent completions for flags, value-accepting options (with enum support), and subcommands.

**Issues found:**
- Minor filtering bug in `demo.curl.sh:42` where positional arg aliases (like `<command>`) are not filtered from the `FLAGS` output alongside `$1`, causing `<command>` to incorrectly appear as a flag option

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it only adds demo files and doesn't modify core functionality
- Score reflects that this is a demo-only addition with isolated scope. The single logic bug found (positional arg alias filtering) is minor and only affects the demo's completion output format, not runtime behavior. All changes follow project naming conventions (`demos/demo.*.sh`) and integrate properly with existing `_arguments.sh` infrastructure.
- Pay attention to `demos/demo.curl.sh` line 42 - fix the filtering logic to exclude both positional args and their aliases from FLAGS output

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| demos/demo.curl.sh | Mock curl CLI that exposes completion metadata via `--completion-data`; uses `_arguments.sh` for parsing; minor pattern matching issue in line 42 |
| demos/demo.curl.bash | Bash completion adapter that loads metadata from `demo.curl.sh --completion-data`; implements proper completion for flags, value flags, commands, and enums |
| demos/demo.curl.zsh | Zsh completion adapter mirroring bash functionality; uses Zsh-specific syntax for array handling and completion |
| demos/demo.curl.completion.md | Documentation explaining the completion PoC, available commands/flags, and two integration approaches (simple vs elegant) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Shell as Shell (Bash/Zsh)
    participant Adapter as Completion Adapter<br/>(demo.curl.bash/zsh)
    participant CLI as CLI Script<br/>(demo.curl.sh)
    participant ArgsLib as _arguments.sh

    Note over User,ArgsLib: Initialization Phase
    User->>Shell: source demo.curl.bash
    Shell->>Adapter: Load completion adapter
    Note over Adapter: Define __demo_curl_load_data()
    Shell->>Shell: Register completion function

    Note over User,ArgsLib: Completion Trigger
    User->>Shell: Type "demo-curl <TAB>"
    Shell->>Adapter: Call _demo_curl_complete()
    
    alt First time (data not loaded)
        Adapter->>CLI: ./demo.curl.sh --completion-data
        CLI->>ArgsLib: source _arguments.sh
        CLI->>ArgsLib: parse:mapping()
        ArgsLib->>CLI: Build lookup_arguments arrays
        CLI->>CLI: demo:completion:emit()
        Note over CLI: Extract flags, value_flags,<br/>commands, enums from arrays
        CLI->>Adapter: Return FLAGS=...<br/>VALUE_FLAGS=...<br/>COMMANDS=...<br/>REQUEST_ENUM=...
        Adapter->>Adapter: Parse & cache data
        Note over Adapter: __demo_curl_loaded=1
    end

    Adapter->>Adapter: Determine completion context
    
    alt Previous word is value flag
        Note over Adapter: e.g., "--request" or "-X"
        Adapter->>Shell: Complete with REQUEST_ENUM
    else Current word starts with "-"
        Adapter->>Shell: Complete with FLAGS
    else First positional arg
        Adapter->>Shell: Complete with COMMANDS
    end
    
    Shell->>User: Display completion options
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->