### PR TITLE
Refactor timeout patch application with fallback injection mechanism

### DIFF
--- a/patches/apply.macos.sh
+++ b/patches/apply.macos.sh
@@ -2,21 +2,22 @@
 # Apply ShellSpec timeout patch (macOS)
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-01-19
-## Version: 2.0.4
+## Last revisit: 2026-02-10
+## Version: 3.0.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
-
 set -euo pipefail
 
-# Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATCH_FILE="$SCRIPT_DIR/shellspec-0.28.1-to-0.29.0-timeout.patch"
+FILES_DIR="$SCRIPT_DIR/files"
+INJECT_SCRIPT="$SCRIPT_DIR/inject-timeout.sh"
 
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
@@ -25,71 +26,51 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_step() { echo -e "${BLUE}[STEP]${NC} $*"; }
 
-# 1. Verify Patch File Exists
-if [[ ! -f "$PATCH_FILE" ]]; then
-  log_error "Patch file not found: $PATCH_FILE"
-  exit 1
-fi
-
-# 2. Find ShellSpec Dir (macOS/Homebrew specific)
-# 2. Find ShellSpec Dir (macOS/Homebrew specific)
+# 1. Find ShellSpec Dir (macOS/Homebrew specific)
 find_shellspec_dir() {
     local shellspec_bin
     if ! shellspec_bin="$(command -v shellspec)"; then
         log_error "ShellSpec not found"
         return 1
     fi
-    
-    # Resolve symlink to find the actual binary location
+
+    # Resolve symlinks to find actual binary location
     local resolved_bin="$shellspec_bin"
-    if [[ -L "$shellspec_bin" ]]; then
-         local resolved
-         resolved="$(readlink "$shellspec_bin")"
-         local bin_dir="$(dirname "$shellspec_bin")"
-         # Handle relative link
-         if [[ "$resolved" != /* ]]; then
-            resolved="$(cd "$bin_dir" && pwd)/$resolved"
-         fi
-         # Recursively resolve
-         while [[ -L "$resolved" ]]; do
-            local link_dir="$(dirname "$resolved")"
-            resolved="$(readlink "$resolved")"
-            if [[ "$resolved" != /* ]]; then
-                resolved="$link_dir/$resolved"
-            fi
-        done
-        resolved_bin="$resolved"
-    fi
-    
-    # Get the directory containing the shellspec binary
+    while [[ -L "$resolved_bin" ]]; do
+        local link_dir
+        link_dir="$(cd "$(dirname "$resolved_bin")" && pwd)"
+        local target
+        target="$(readlink "$resolved_bin")"
+        if [[ "$target" != /* ]]; then
+            target="$link_dir/$target"
+        fi
+        resolved_bin="$target"
+    done
+
     local bin_dir
-    bin_dir="$(dirname "$resolved_bin")"
+    bin_dir="$(cd "$(dirname "$resolved_bin")" && pwd)"
 
-    # Heuristic: Check where lib/core/core.sh lives relative to this binary.
-    # 1. Manual install: Binary is in root, lib is in $ROOT/lib/core/core.sh
-    # 2. Standard install: Binary is in bin/, lib is in $ROOT/../lib/core/core.sh
-    # 3. Homebrew: lib is in $ROOT/lib/shellspec/lib/core/core.sh -> We want $ROOT/lib/shellspec
-
-    # Case 1: Manual install - check if lib/core/core.sh exists in the same directory as the binary
+    # Case 1: Manual install - lib/ next to binary
     if [[ -f "$bin_dir/lib/core/core.sh" ]]; then
         echo "$bin_dir"
         return 0
     fi
 
-    # Case 2: Standard install - go up one level from bin/
-    local install_root
-    install_root="$(cd "$bin_dir/.." && pwd)"
-
-    if [[ -f "$install_root/lib/core/core.sh" ]]; then
-        echo "$install_root"
-        return 0
-    elif [[ -f "$install_root/lib/shellspec/lib/core/core.sh" ]]; then
-        echo "$install_root/lib/shellspec"
+    # Case 2: Standard install (bin/shellspec -> ../lib/)
+    local parent_dir
+    parent_dir="$(cd "$bin_dir/.." && pwd)"
+    if [[ -f "$parent_dir/lib/core/core.sh" ]]; then
+        echo "$parent_dir"
         return 0
     fi
 
-    # Fallback: Just return install_root and hope
-    echo "$install_root" 
+    # Case 3: Homebrew Cellar layout (lib/shellspec/lib/)
+    if [[ -f "$parent_dir/lib/shellspec/lib/core/core.sh" ]]; then
+        echo "$parent_dir/lib/shellspec"
+        return 0
+    fi
+
+    echo "$parent_dir"
 }
 
 if ! SHELLSPEC_DIR="$(find_shellspec_dir)"; then
@@ -98,53 +79,71 @@ if ! SHELLSPEC_DIR="$(find_shellspec_dir)"; then
 fi
 
 if [[ ! -f "$SHELLSPEC_DIR/lib/core/core.sh" ]]; then
-  log_error "ShellSpec core not found under $SHELLSPEC_DIR"
-  exit 1
+    log_error "ShellSpec core not found under $SHELLSPEC_DIR"
+    exit 1
 fi
 
 log_info "ShellSpec Dir: $SHELLSPEC_DIR"
 
-# 3. Check Marker
+# 2. Check if already patched
 MARKER_FILE="$SHELLSPEC_DIR/.patched-timeout"
 if [[ -f "$MARKER_FILE" ]]; then
-  exit 0
+    exit 0
 fi
 
 if "$SHELLSPEC_DIR/shellspec" --help 2>/dev/null | grep -q -- '--timeout'; then
-  touch "$MARKER_FILE"
-  exit 0
+    touch "$MARKER_FILE" 2>/dev/null || true
+    exit 0
 fi
 
-# 4. Apply Patch
+# 3. Try applying patch (with fuzz tolerance)
 log_step "Applying patch..."
 cd "$SHELLSPEC_DIR"
 
-if ! command -v patch >/dev/null 2>&1; then
-    log_error "patch command missing"
-    exit 1
+patch_succeeded=false
+
+if command -v patch >/dev/null 2>&1 && [[ -f "$PATCH_FILE" ]]; then
+    PATCH_OPTS=(--batch --forward -p1 -N --fuzz=3)
+
+    if patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" >/dev/null 2>&1; then
+        log_info "Patch dry-run OK, applying..."
+        if patch "${PATCH_OPTS[@]}" -i "$PATCH_FILE"; then
+            patch_succeeded=true
+        fi
+    else
+        log_warn "Patch dry-run failed (source files differ from expected). Trying force-apply..."
+        # Force apply - will apply hunks that match, skip others
+        patch --batch --forward -p1 -N --fuzz=3 --force -i "$PATCH_FILE" 2>&1 || true
+        log_info "Force-apply done (some hunks may have been skipped)"
+    fi
+
+    # Clean up rejection/backup files
+    find "$SHELLSPEC_DIR" -maxdepth 3 \( -name "*.rej" -o -name "*.orig" \) -delete 2>/dev/null || true
 fi
 
-# Apply patch (tolerant of partials)
-PATCH_OPTS=(--batch --forward -p1 -N)
-log_info "Checking patch applicability..."
-if ! patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" >/dev/null; then
-    log_error "Patch dry-run failed. Please ensure ShellSpec sources match 0.28.1"
-    exit 1
+# 4. Direct injection fallback - ensures all modifications are in place
+#    This is idempotent: skips files already patched (by patch or previous run)
+if [[ "$patch_succeeded" != "true" ]]; then
+    if [[ -x "$INJECT_SCRIPT" ]] || [[ -f "$INJECT_SCRIPT" ]]; then
+        log_step "Running direct file injection fallback..."
+        bash "$INJECT_SCRIPT" "$SHELLSPEC_DIR" "$FILES_DIR"
+    else
+        log_error "Inject script not found: $INJECT_SCRIPT"
+        exit 1
+    fi
+else
+    # Even when patch succeeds, ensure new standalone files are in place
+    if [[ -d "$FILES_DIR" ]]; then
+        mkdir -p "$SHELLSPEC_DIR/lib/libexec" "$SHELLSPEC_DIR/libexec"
+        cp "$FILES_DIR/lib/libexec/timeout-parser.sh" "$SHELLSPEC_DIR/lib/libexec/timeout-parser.sh" 2>/dev/null || true
+        cp "$FILES_DIR/libexec/shellspec-timeout-watchdog.sh" "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh" 2>/dev/null || true
+        chmod +x "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh" 2>/dev/null || true
+    fi
 fi
 
-log_info "Applying patch..."
-patch "${PATCH_OPTS[@]}" -i "$PATCH_FILE"
+# 5. Verify patch was applied (functional test)
+log_step "Verifying timeout feature..."
 
-# 5. Handle bin/shellspec.rej (Harmless)
-if [[ -f "bin/shellspec.rej" ]]; then
-    log_info "Removing harmless bin/shellspec.rej..."
-    rm "bin/shellspec.rej"
-fi
-
-# 6. Verify patch was applied
-log_step "Verifying patch..."
-
-# Functional verification: Create a test that times out
 TEST_FILE="$SHELLSPEC_DIR/timeout_verification_spec.sh"
 cat <<'EOF' > "$TEST_FILE"
 Describe "timeout verification"
@@ -155,25 +154,18 @@ Describe "timeout verification"
 End
 EOF
 
-# Run the test and measure duration
 START_TIME=$(date +%s)
 "$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
-
-# Cleanup test file
 rm -f "$TEST_FILE"
 
-# If timeout is working, test should abort before 2 seconds
 if [[ $DURATION -lt 2 ]]; then
-    VERSION="$("$SHELLSPEC_DIR/shellspec" --version)"
-    log_info "Success! Timeout feature verified (Duration: ${DURATION}s). Version: $VERSION"
-    touch "$MARKER_FILE"
+    VERSION="$("$SHELLSPEC_DIR/shellspec" --version 2>/dev/null || echo "unknown")"
+    log_info "Timeout feature verified (${DURATION}s). Version: $VERSION"
+    touch "$MARKER_FILE" 2>/dev/null || true
     exit 0
 else
-    log_error "Verification failed. Test did not timeout (Duration: ${DURATION}s)."
-    log_error "Expected duration < 2s, which would indicate timeout feature is working."
+    log_error "Verification failed: test did not timeout (Duration: ${DURATION}s, expected <2s)"
     exit 1
 fi
-
-

--- a/patches/files/lib/libexec/timeout-parser.sh
+++ b/patches/files/lib/libexec/timeout-parser.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# shellcheck disable=SC2004
+
+# Parse timeout format: 30, 30s, 1m, 1m30s → seconds
+shellspec_parse_timeout() {
+  timeout_value="$1"
+  timeout_seconds=0
+
+  case $timeout_value in
+    0) echo 0; return 0 ;;
+    "") echo "${SHELLSPEC_TIMEOUT:-60}"; return 0 ;;
+  esac
+
+  case $timeout_value in
+    *[mM]*)
+      timeout_minutes="${timeout_value%%[mM]*}"
+      timeout_minutes="${timeout_minutes##*[^0-9]}"
+      timeout_seconds=$((${timeout_minutes:-0} * 60))
+      timeout_value="${timeout_value#*[mM]}"
+      ;;
+  esac
+
+  case $timeout_value in
+    *[sS]*) timeout_value="${timeout_value%%[sS]*}" ;;
+  esac
+
+  case $timeout_value in
+    *[0-9]*)
+      timeout_value="${timeout_value##*[^0-9]}"
+      timeout_seconds=$((timeout_seconds + ${timeout_value:-0}))
+      ;;
+  esac
+
+  echo "$timeout_seconds"
+}

--- a/patches/files/libexec/shellspec-timeout-watchdog.sh
+++ b/patches/files/libexec/shellspec-timeout-watchdog.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# shellcheck disable=SC2016
+
+set -eu
+
+if [ "${SHELLSPEC_PATH:-}" ]; then
+  PATH="$SHELLSPEC_PATH"
+  export PATH
+fi
+
+# $1 timeout seconds
+# $2 test pid
+# $3 signal file path
+# $4 result file path
+
+timeout_seconds="$1"
+test_pid="$2"
+signal_file="$3"
+result_file="$4"
+
+sleep "$timeout_seconds" &
+sleep_pid=$!
+
+while kill -0 "$sleep_pid" 2>/dev/null; do
+  if ! kill -0 "$test_pid" 2>/dev/null; then
+    kill "$sleep_pid" 2>/dev/null || :
+    exit 0
+  fi
+
+  if [ ! -e "$signal_file" ]; then
+    kill "$sleep_pid" 2>/dev/null || :
+    exit 0
+  fi
+
+  sleep 0.1 2>/dev/null || sleep 1
+done
+
+if kill -0 "$test_pid" 2>/dev/null; then
+  echo "TIMEOUT" > "$result_file"
+  kill -TERM "$test_pid" 2>/dev/null || :
+  sleep 1
+  kill -KILL "$test_pid" 2>/dev/null || :
+fi
+
+rm -f "$signal_file" 2>/dev/null || :

--- a/patches/inject-timeout.sh
+++ b/patches/inject-timeout.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Direct file injection of ShellSpec timeout feature (patch-free fallback)
+# Uses perl for portable multi-line text manipulation (available on macOS + Linux)
+
+## Copyright (C) 2017-present, Oleksandr Kucherenko
+## Last revisit: 2026-02-10
+## Version: 1.0.0
+## License: MIT
+## Source: https://github.com/OleksandrKucherenko/e-bash
+
+# Usage: inject-timeout.sh <SHELLSPEC_DIR> <FILES_DIR>
+# Injects timeout feature directly into ShellSpec source files.
+# Idempotent - safe to run multiple times.
+
+set -euo pipefail
+
+SHELLSPEC_DIR="${1:?Usage: inject-timeout.sh <SHELLSPEC_DIR> <FILES_DIR>}"
+FILES_DIR="${2:?Usage: inject-timeout.sh <SHELLSPEC_DIR> <FILES_DIR>}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INJECT]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[INJECT]${NC} $*"; }
+log_error() { echo -e "${RED}[INJECT]${NC} $*" >&2; }
+
+# Verify perl is available
+if ! command -v perl >/dev/null 2>&1; then
+    log_error "perl is required for direct injection but not found"
+    exit 1
+fi
+
+# --- 1. Copy new files ---
+log_info "Installing new timeout files..."
+
+mkdir -p "$SHELLSPEC_DIR/lib/libexec"
+mkdir -p "$SHELLSPEC_DIR/libexec"
+
+cp "$FILES_DIR/lib/libexec/timeout-parser.sh" "$SHELLSPEC_DIR/lib/libexec/timeout-parser.sh"
+cp "$FILES_DIR/libexec/shellspec-timeout-watchdog.sh" "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh"
+chmod +x "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh"
+
+# --- 2. shellspec (main binary): Update version ---
+if grep -q "SHELLSPEC_VERSION='0.28" "$SHELLSPEC_DIR/shellspec" 2>/dev/null; then
+    if ! grep -q "0.29.0-dev" "$SHELLSPEC_DIR/shellspec"; then
+        log_info "Updating version string..."
+        perl -i -pe "s/SHELLSPEC_VERSION='0\.28\.\d+'/SHELLSPEC_VERSION='0.29.0-dev'/" "$SHELLSPEC_DIR/shellspec"
+    fi
+fi
+
+# --- 3. bootstrap.sh: Load timeout parser ---
+if ! grep -q "timeout-parser" "$SHELLSPEC_DIR/lib/bootstrap.sh" 2>/dev/null; then
+    log_info "Patching bootstrap.sh..."
+    perl -i -pe '
+        if (/\.\s+"\$SHELLSPEC_LIB\/general\.sh"/ && !$done) {
+            $_ .= qq{\n# Load timeout parser (fallback to simple parser if missing)\nif [ -f "\$SHELLSPEC_LIB/libexec/timeout-parser.sh" ]; then\n  . "\$SHELLSPEC_LIB/libexec/timeout-parser.sh"\nelse\n  shellspec_parse_timeout() { echo "\${1:-\${SHELLSPEC_TIMEOUT:-60}}"; }\nfi\n};
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/bootstrap.sh"
+fi
+
+# --- 4. outputs.sh: Add TIMEOUT output function ---
+if ! grep -q "shellspec_output_TIMEOUT" "$SHELLSPEC_DIR/lib/core/outputs.sh" 2>/dev/null; then
+    log_info "Patching outputs.sh..."
+    perl -i -pe '
+        if (/^shellspec_output_NOT_IMPLEMENTED\(\)/ && !$done) {
+            $_ = qq{shellspec_output_TIMEOUT() {\n  shellspec_output_statement "tag:timeout" "note:TIMEOUT" "fail:y" \\\\\n    "timeout:\$1" \\\\\n    "failure_message:\${SHELLSPEC_LINENO:+<\$SHELLSPEC_LINENO>}Test exceeded timeout" \\\\\n    "message:Test exceeded timeout of \$1 seconds"\n}\n\n} . $_;
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/core/outputs.sh"
+fi
+
+# --- 5. directives: Add %timeout ---
+if ! grep -q "timeout" "$SHELLSPEC_DIR/lib/libexec/grammar/directives" 2>/dev/null; then
+    log_info "Patching directives..."
+    echo '%timeout     => timeout_metadata' >> "$SHELLSPEC_DIR/lib/libexec/grammar/directives"
+fi
+
+# --- 6. optparser.sh: Add check_timeout_format ---
+if ! grep -q "check_timeout_format" "$SHELLSPEC_DIR/lib/libexec/optparser/optparser.sh" 2>/dev/null; then
+    log_info "Patching optparser.sh..."
+    # Add function before check_formatter
+    perl -i -pe '
+        if (/^check_formatter\(\)/ && !$done) {
+            $_ = qq{check_timeout_format() {\n  case \$OPTARG in\n    0) return 0 ;;\n    *[!0-9smSM]*) return 1 ;;\n    *[0-9]|*[sSmM]) return 0 ;;\n    *) return 1 ;;\n  esac\n}\n\n} . $_;
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/libexec/optparser/optparser.sh"
+    # Add error handler
+    perl -i -pe '
+        if (/check_number:\*\)/ && !$done) {
+            $_ .= qq{    check_timeout_format:*) set -- "\$1" "Invalid timeout format (use NUMBER[s|m], e.g., 30, 30s, 1m): \$4" ;;\n};
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/libexec/optparser/optparser.sh"
+fi
+
+# --- 7. parser_definition.sh: Add --timeout options ---
+if ! grep -q "TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition.sh" 2>/dev/null; then
+    log_info "Patching parser_definition.sh..."
+    perl -i -pe '
+        if (/--log-file/ && !$done) {
+            $_ = qq{  param TIMEOUT --timeout validate:check_timeout_format init:=60 var:SECONDS -- \\\\\n    '\''Specify the default timeout for each test [default: 60]'\'' \\\\\n    '\''  Format: NUMBER[s|m] (e.g., 30, 30s, 1m, 90s)'\'' \\\\\n    '\''  Set to 0 to disable timeout'\''\n\n  flag TIMEOUT --no-timeout on:0 -- \\\\\n    '\''Disable timeout for all tests'\''\n\n} . $_;
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition.sh"
+fi
+
+# --- 8. parser_definition_generated.sh: The big one - add exports + CLI parsing + help text ---
+if ! grep -q "SHELLSPEC_TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh" 2>/dev/null; then
+    log_info "Patching parser_definition_generated.sh..."
+
+    # Add export line
+    perl -i -pe '
+        if (/SHELLSPEC_LOGFILE/ && !$done) {
+            $_ = qq{export SHELLSPEC_TIMEOUT='\''60'\''\n} . $_;
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh"
+
+    # Add CLI completion entries (before --log-file completion)
+    perl -i -0pe '
+        s{(case\s+'\''--log-file'\'' in)}{      case '\''--timeout'\'' in
+        "\$1") OPTARG=; break ;;
+        \$1*) OPTARG="\$OPTARG --timeout"
+      esac
+      case '\''--no-timeout'\'' in
+        "\$1") OPTARG=; break ;;
+        \$1*) OPTARG="\$OPTARG --no-timeout"
+      esac
+      $1}ms' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh"
+
+    # Add option handlers (before --log-file handler)
+    perl -i -0pe "
+        s{(\\s+'\\''\\'--log-file'\\''\\'\\))}{      '--timeout')
+        [ \\\$# -le 1 ] && set \"required\" \"\\\$1\" && break
+        OPTARG=\\\$2
+        check_timeout_format || { set -- check_timeout_format:\\\$? \"\\\$1\" check_timeout_format; break; }
+        export SHELLSPEC_TIMEOUT=\"\\\$OPTARG\"
+        shift ;;
+      '--no-timeout')
+        [ \"\\\${OPTARG:-}\" ] && OPTARG=\\\${OPTARG#*\\\\=} && set \"noarg\" \"\\\$1\" && break
+        eval '[ \\\${OPTARG+x} ] &&:' && OPTARG='0' || OPTARG=''
+        export SHELLSPEC_TIMEOUT=\"\\\$OPTARG\"
+        ;;\n\$1}ms" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh"
+
+    # Add help text (before --log-file help line)
+    perl -i -pe '
+        if (/--log-file LOGFILE/ && !$done) {
+            $_ = qq{        --timeout SECONDS           Specify the default timeout for each test [default: 60]\n                                      Format: NUMBER[s|m] (e.g., 30, 30s, 1m, 90s)\n                                      Set to 0 to disable timeout\n        --no-timeout                Disable timeout for all tests\n} . $_;
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh"
+fi
+
+# --- 9. translator.sh: Add timeout override parsing ---
+if ! grep -q "shellspec_timeout_override" "$SHELLSPEC_DIR/lib/libexec/translator.sh" 2>/dev/null; then
+    log_info "Patching translator.sh..."
+
+    # Add timeout_override init in check_filter + timeout parsing before check_tag_filter
+    perl -i -0pe '
+        s{(check_filter\(\)\s*\{[^\n]*\n\s*check_filter="\$1")}{$1\n  shellspec_timeout_override=""}ms;
+
+        s{(\s+check_tag_filter\s+"\$\@")}{
+  while [ \$# -gt 0 ]; do
+    case \$1 in
+      timeout:*) shellspec_timeout_override="\${1#timeout:}" ;;
+    esac
+    shift
+  done
+
+$1}ms;
+
+        s{(^include\(\)\s*\{)}{timeout_metadata() {\n  :\n}\n\n$1}ms;
+    ' "$SHELLSPEC_DIR/lib/libexec/translator.sh"
+fi
+
+# --- 10. shellspec-translate.sh: Inject SHELLSPEC_EXAMPLE_TIMEOUT ---
+if ! grep -q "SHELLSPEC_EXAMPLE_TIMEOUT" "$SHELLSPEC_DIR/libexec/shellspec-translate.sh" 2>/dev/null; then
+    log_info "Patching shellspec-translate.sh..."
+    perl -i -pe '
+        if (/shellspec_example_id/ && !$done) {
+            $_ .= qq{  if [ "\${shellspec_timeout_override:-}" ]; then\n    putsn "SHELLSPEC_EXAMPLE_TIMEOUT='\''\\$shellspec_timeout_override'\''"\n  else\n    putsn "SHELLSPEC_EXAMPLE_TIMEOUT='\'''\''"\n  fi\n};
+            $done = 1;
+        }
+    ' "$SHELLSPEC_DIR/libexec/shellspec-translate.sh"
+fi
+
+# --- 11. dsl.sh: Add timeout execution logic (most complex modification) ---
+if ! grep -q "shellspec_timeout_seconds" "$SHELLSPEC_DIR/lib/core/dsl.sh" 2>/dev/null; then
+    log_info "Patching dsl.sh (timeout execution logic)..."
+    perl -i -0777 -pe '
+        # Match the original execution block pattern (flexible whitespace matching)
+        s{
+            ([ \t]+return[ \t]+0\n[ \t]+fi\n)        # end of skip block
+            (\n[ \t]+shellspec_profile_start)          # profile start
+            (\n[ \t]+case[ \t]+\$-[ \t]+in\n[ \t]+\*e\*\).*?\n[ \t]+\*\).*?\n[ \t]+esac\n[ \t]+set[ \t]+\+e\n)  # set +e block
+            [ \t]+\([ \t]+set[ \t]+-e\n              # ( set -e
+            [ \t]+shift\n                             # shift
+            [ \t]+case[ \t]+\$\#.*?\n                  # case $#
+            [ \t]+0\)[ \t]+shellspec_invoke_example[ \t]+3>&2.*?\n  # 0) case
+            [ \t]+\*\)[ \t]+shellspec_invoke_example.*?3>&2.*?\n    # *) case
+            [ \t]+esac\n                              # esac
+            [ \t]+\)\n                                # )
+            [ \t]+set[ \t]+"\$1"[ \t]+--[ \t]+\$\?[ \t]+"\$SHELLSPEC_LEAK_FILE"  # set result
+        }
+        {$1
+  # Timeout configuration per example
+  shellspec_effective_timeout="\${SHELLSPEC_EXAMPLE_TIMEOUT:-\${SHELLSPEC_TIMEOUT:-60}}"
+  shellspec_timeout_seconds=\$(shellspec_parse_timeout "\$shellspec_effective_timeout")
+  shellspec_timeout_seconds=\${shellspec_timeout_seconds:-0}
+  SHELLSPEC_TIMEOUT_SIGNAL_FILE="\$SHELLSPEC_STDIO_FILE_BASE.timeout_signal"
+  SHELLSPEC_TIMEOUT_RESULT_FILE="\$SHELLSPEC_STDIO_FILE_BASE.timeout_result"
+  if [ "\$shellspec_timeout_seconds" -gt 0 ] 2>/dev/null; then
+    : > "\$SHELLSPEC_TIMEOUT_SIGNAL_FILE"
+    : > "\$SHELLSPEC_TIMEOUT_RESULT_FILE"
+  fi
+$2$3
+  if [ "\$shellspec_timeout_seconds" -gt 0 ] 2>/dev/null; then
+    ( set -e
+      shift
+      case \$# in
+        0) shellspec_invoke_example 3>&2 ;;
+        *) shellspec_invoke_example "\$@" 3>&2 ;;
+      esac
+    ) &
+    shellspec_test_pid=\$!
+
+    ( "\$SHELLSPEC_SHELL" "\$SHELLSPEC_LIBEXEC/shellspec-timeout-watchdog.sh" \\
+      "\$shellspec_timeout_seconds" "\$shellspec_test_pid" \\
+      "\$SHELLSPEC_TIMEOUT_SIGNAL_FILE" "\$SHELLSPEC_TIMEOUT_RESULT_FILE" \\
+    ) &
+
+    wait "\$shellspec_test_pid"
+    shellspec_exit_status=\$?
+
+    shellspec_rm -f "\$SHELLSPEC_TIMEOUT_SIGNAL_FILE"
+    if [ -s "\$SHELLSPEC_TIMEOUT_RESULT_FILE" ]; then
+      shellspec_exit_status=124
+      shellspec_timeout_occurred=1
+    else
+      shellspec_timeout_occurred=0
+    fi
+    shellspec_rm -f "\$SHELLSPEC_TIMEOUT_RESULT_FILE"
+  else
+    ( set -e
+      shift
+      case \$# in
+        0) shellspec_invoke_example 3>&2 ;;
+        *) shellspec_invoke_example "\$@" 3>&2 ;;
+      esac
+    )
+    shellspec_exit_status=\$?
+    shellspec_timeout_occurred=0
+  fi
+
+  set "\$1" -- \$shellspec_exit_status "\$SHELLSPEC_LEAK_FILE"
+
+  if [ "\$shellspec_timeout_occurred" -eq 1 ]; then
+    shellspec_output TIMEOUT "\$shellspec_timeout_seconds"
+    shellspec_output FAILED
+    shellspec_profile_end
+    return 0
+  fi
+}xms' "$SHELLSPEC_DIR/lib/core/dsl.sh"
+
+    # Verify the dsl.sh modification worked
+    if ! grep -q "shellspec_timeout_seconds" "$SHELLSPEC_DIR/lib/core/dsl.sh"; then
+        log_warn "dsl.sh regex match failed - timeout per-example may not work"
+        log_warn "This is OK if the patch command already applied this hunk"
+    fi
+fi
+
+log_info "Direct injection complete"


### PR DESCRIPTION
## Summary
Refactored the ShellSpec timeout patch application scripts to use a two-stage approach: attempt standard patch application first, then fall back to direct file injection if needed. This improves robustness across different ShellSpec installations and versions.

## Key Changes

### Version Updates
- Updated both `apply.linux.sh` and `apply.macos.sh` to version 3.0.0
- Updated last revisit date to 2026-02-10

### Patch Application Strategy
- **Stage 1 (Patch)**: Try applying the standard patch with `--fuzz=3` tolerance for minor source differences
- **Stage 2 (Fallback)**: If patch fails, use direct file injection via new `inject-timeout.sh` script
- Added cleanup of `.rej` and `.orig` files after patch attempts
- Made patch application more lenient with force-apply option when dry-run fails

### New Files
- **`patches/inject-timeout.sh`**: New idempotent injection script that directly modifies ShellSpec source files using perl
  - Copies new timeout utility files (`timeout-parser.sh`, `shellspec-timeout-watchdog.sh`)
  - Patches 11 key ShellSpec files to add timeout functionality
  - Uses perl for portable multi-line text manipulation
  - Safe to run multiple times (idempotent)

- **`patches/files/lib/libexec/timeout-parser.sh`**: New utility to parse timeout formats (30, 30s, 1m, 1m30s → seconds)

- **`patches/files/libexec/shellspec-timeout-watchdog.sh`**: New watchdog process that monitors test execution and enforces timeouts

### Script Improvements
- Simplified symlink resolution logic in `find_shellspec_dir()` function
- Improved error handling with better fallback behavior
- Enhanced logging with clearer step descriptions
- Made marker file creation more robust with error suppression
- Improved verification test with better error messages
- Consistent formatting and indentation across both scripts

### Robustness Enhancements
- Scripts now handle cases where patch command is unavailable
- Graceful degradation when patch fails (falls back to injection)
- Ensures new standalone files are copied even when patch succeeds
- Better handling of edge cases (missing files, permission issues)
- More informative warning messages when patch dry-run fails

## Implementation Details
The injection script uses perl regex with multi-line matching (`-0pe` flag) to handle complex modifications like the timeout execution logic in `dsl.sh`. This approach is more portable than sed and handles the intricate pattern matching needed for proper code injection.

The two-stage approach ensures compatibility with:
- Standard ShellSpec installations
- Homebrew installations (macOS)
- Manual/custom installations
- Slightly modified source versions (via fuzz matching)

https://claude.ai/code/session_011Espkg32p5DoL8qvoE4Hni

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors the ShellSpec timeout patch application on Linux/macOS into a two-stage process: attempt to apply the existing patch with fuzz/force tolerance, then fall back to a new `inject-timeout.sh` script that directly edits ShellSpec sources and installs new timeout helper files.

The overall flow fits the repo’s existing patch-based approach, but adds an injection path intended to work when upstream sources diverge (e.g., Homebrew/custom installs).

Issues to fix before merge:
- `inject-timeout.sh` contains critical Perl replacement bugs where `$1` in replacement strings expands to the *shell* argument (install dir) rather than Perl backreferences, which can corrupt `parser_definition_generated.sh`.
- `apply.*.sh` can incorrectly run injection after a successful `patch --force` because `patch_succeeded` isn’t updated in that path, leading to mixed patch+injection state.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge until the injection script’s Perl replacements are fixed.
- The new fallback mechanism is a good direction, but `inject-timeout.sh` currently uses `$1` in Perl replacement strings, which expands to the shell’s first arg and will likely corrupt generated optparser files. Additionally, the apply scripts may run injection after a force-applied patch, creating inconsistent mixed modifications.
- patches/inject-timeout.sh; patches/apply.linux.sh; patches/apply.macos.sh

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| patches/apply.linux.sh | Refactors patch application to try `patch` (with fuzz/force) then fall back to injection; bug: `patch_succeeded` never becomes true on successful `--force`, so injection can run even after force-applied patch. |
| patches/apply.macos.sh | Same two-stage patch→inject flow as Linux; same issue where `patch_succeeded` stays false after `patch --force` and triggers injection regardless. |
| patches/inject-timeout.sh | Adds perl-based direct injection to modify multiple ShellSpec files; critical bug: perl replacements incorrectly use `$1` in replacement text, expanding to the shell argument instead of Perl backreferences, likely corrupting target files. |
| patches/files/lib/libexec/timeout-parser.sh | Adds POSIX sh helper to parse timeout strings into seconds; looks self-contained and safe. |
| patches/files/libexec/shellspec-timeout-watchdog.sh | Adds watchdog that sleeps then kills test PID and writes a result flag; straightforward and consistent with intended timeout behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Apply as apply.*.sh
  participant Patch as patch(1)
  participant Inject as inject-timeout.sh
  participant FS as ShellSpec FS

  User->>Apply: run apply script
  Apply->>FS: locate SHELLSPEC_DIR (resolve symlinks)
  Apply->>FS: check marker/help for --timeout
  alt patch available and patch file exists
    Apply->>Patch: patch --dry-run -i patchfile
    alt dry-run OK
      Apply->>Patch: patch -i patchfile
      Patch->>FS: modify ShellSpec sources
      Apply->>FS: copy new timeout helper files
    else dry-run failed
      Apply->>Patch: patch --force -i patchfile
      Patch->>FS: apply matching hunks (partial)
      Apply->>FS: cleanup *.rej/*.orig
      Apply->>Inject: run injection fallback
      Inject->>FS: copy helper files
      Inject->>FS: perl edits across ShellSpec files
    end
  else patch missing or patch file missing
    Apply->>Inject: run injection fallback
    Inject->>FS: copy helper files
    Inject->>FS: perl edits across ShellSpec files
  end
  Apply->>FS: write & run timeout verification spec
  Apply->>FS: create marker file on success
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=284f43e6-fa45-4561-962c-d4a2b8d7f2ac))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=6476e7be-2840-4648-87e6-7cf2c5ed4d12))

<!-- /greptile_comment -->