### PR TITLE
Improve ShellSpec timeout patch robustness and diagnostics

### DIFF
--- a/bin/wsl/xdg-open.sh
+++ b/bin/wsl/xdg-open.sh
@@ -202,7 +202,7 @@ function xdg:launcher:exe() {
   local selection="$1"
   case "$selection" in
   "powershell" | "powershell-scoop") echo "powershell.exe" ;;
-  "pwsh" | "pwsh-scoop" | "pwsh-winget") echo "pwsh.exe" ;;
+  "pwsh" | "pwsh-scoop" | "pwsh-winget" | "pwsh (scoop)" | "pwsh (winget)") echo "pwsh.exe" ;;
   "cmd") echo "cmd.exe" ;;
   *) echo "powershell.exe" ;; # Default fallback
   esac
@@ -228,10 +228,10 @@ function xdg:launcher:path() {
   scoop_dir=$(xdg:windows:scoop_dir)
 
   case "$selection" in
-  "pwsh-winget")
+  "pwsh-winget" | "pwsh (winget)")
     echo "$XDG_WSL_WIN/PowerShell/7/pwsh.exe"
     ;;
-  "pwsh-scoop")
+  "pwsh-scoop" | "pwsh (scoop)")
     if [[ -n "$scoop_dir" ]]; then
       echo "$scoop_dir/shims/pwsh.exe"
     else

--- a/patches/apply.linux.sh
+++ b/patches/apply.linux.sh
@@ -3,7 +3,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2026-02-23
-## Version: 3.1.0
+## Version: 3.2.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -105,13 +105,16 @@ patch_succeeded=false
 if command -v patch >/dev/null 2>&1 && [[ -f "$PATCH_FILE" ]]; then
     PATCH_OPTS=(--batch --forward -p1 -N --fuzz=3)
 
-    if patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" >/dev/null 2>&1; then
+    _dryrun_out=""
+    if _dryrun_out=$(patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" 2>&1); then
         log_info "Patch dry-run OK, applying..."
         if patch "${PATCH_OPTS[@]}" -i "$PATCH_FILE"; then
             patch_succeeded=true
         fi
     else
         log_warn "Patch dry-run failed (source files differ from expected). Using direct injection..."
+        log_warn "Failed hunks (dry-run output):"
+        echo "$_dryrun_out" | grep -E "FAILED|failed|patching" >&2 || true
         # Do NOT force-apply: --force can write partial content to files that tricks
         # the inject script's idempotency checks into skipping those files.
         # The inject script below is the correct robust fallback.
@@ -141,7 +144,25 @@ else
     fi
 fi
 
-# 5. Verify patch was applied (functional test)
+# 5. Pre-verify state check: confirm each key marker is present before running functional test
+_state_ok() {
+    grep -q "$2" "$SHELLSPEC_DIR/$3" 2>/dev/null \
+        && log_info "  ✓ $1" \
+        || log_warn "  ✗ $1 (marker '$2' missing from $3)"
+}
+log_step "Pre-verify state check..."
+_state_ok "shellspec binary version"          "0.29.0-dev"               "shellspec"
+_state_ok "bootstrap.sh: timeout-parser"      "timeout-parser"           "lib/bootstrap.sh"
+_state_ok "outputs.sh: TIMEOUT function"      "shellspec_output_TIMEOUT" "lib/core/outputs.sh"
+_state_ok "directives: %timeout"              "timeout_metadata"         "lib/libexec/grammar/directives"
+_state_ok "optparser.sh: check_timeout"       "check_timeout_format"     "lib/libexec/optparser/optparser.sh"
+_state_ok "parser_definition.sh: TIMEOUT"     "TIMEOUT"                  "lib/libexec/optparser/parser_definition.sh"
+_state_ok "parser_definition_gen: TIMEOUT"    "SHELLSPEC_TIMEOUT"        "lib/libexec/optparser/parser_definition_generated.sh"
+_state_ok "translator.sh: timeout_override"   "shellspec_timeout_override" "lib/libexec/translator.sh"
+_state_ok "shellspec-translate.sh: EXAMPLE"   "SHELLSPEC_EXAMPLE_TIMEOUT" "libexec/shellspec-translate.sh"
+_state_ok "dsl.sh: watchdog invocation"       "shellspec-timeout-watchdog" "lib/core/dsl.sh"
+
+# 6. Verify patch was applied (functional test)
 log_step "Verifying timeout feature..."
 
 TEST_FILE="$SHELLSPEC_DIR/timeout_verification_spec.sh"
@@ -155,7 +176,7 @@ End
 EOF
 
 START_TIME=$(date +%s)
-"$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
+_verify_out=$("$SHELLSPEC_DIR/shellspec" "$TEST_FILE" 2>&1) || true
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 rm -f "$TEST_FILE"
@@ -167,5 +188,7 @@ if [[ $DURATION -lt 2 ]]; then
     exit 0
 else
     log_error "Verification failed: test did not timeout (Duration: ${DURATION}s, expected <2s)"
+    log_error "ShellSpec output from verification test:"
+    echo "$_verify_out" >&2
     exit 1
 fi

--- a/patches/apply.linux.sh
+++ b/patches/apply.linux.sh
@@ -2,8 +2,8 @@
 # Apply ShellSpec timeout patch (Ubuntu/Linux)
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-02-10
-## Version: 3.0.0
+## Last revisit: 2026-02-23
+## Version: 3.1.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -111,10 +111,10 @@ if command -v patch >/dev/null 2>&1 && [[ -f "$PATCH_FILE" ]]; then
             patch_succeeded=true
         fi
     else
-        log_warn "Patch dry-run failed (source files differ from expected). Trying force-apply..."
-        # Force apply - will apply hunks that match, skip others
-        patch --batch --forward -p1 -N --fuzz=3 --force -i "$PATCH_FILE" 2>&1 || true
-        log_info "Force-apply done (some hunks may have been skipped)"
+        log_warn "Patch dry-run failed (source files differ from expected). Using direct injection..."
+        # Do NOT force-apply: --force can write partial content to files that tricks
+        # the inject script's idempotency checks into skipping those files.
+        # The inject script below is the correct robust fallback.
     fi
 
     # Clean up rejection/backup files

--- a/patches/apply.macos.sh
+++ b/patches/apply.macos.sh
@@ -3,7 +3,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2026-02-23
-## Version: 3.1.0
+## Version: 3.2.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -105,13 +105,16 @@ patch_succeeded=false
 if command -v patch >/dev/null 2>&1 && [[ -f "$PATCH_FILE" ]]; then
     PATCH_OPTS=(--batch --forward -p1 -N --fuzz=3)
 
-    if patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" >/dev/null 2>&1; then
+    _dryrun_out=""
+    if _dryrun_out=$(patch "${PATCH_OPTS[@]}" --dry-run -i "$PATCH_FILE" 2>&1); then
         log_info "Patch dry-run OK, applying..."
         if patch "${PATCH_OPTS[@]}" -i "$PATCH_FILE"; then
             patch_succeeded=true
         fi
     else
         log_warn "Patch dry-run failed (source files differ from expected). Using direct injection..."
+        log_warn "Failed hunks (dry-run output):"
+        echo "$_dryrun_out" | grep -E "FAILED|failed|patching" >&2 || true
         # Do NOT force-apply: --force with --fuzz on BSD patch (macOS) can write partial
         # content to files (e.g. dsl.sh gets shellspec_timeout_seconds but not the watchdog
         # invocation), which then tricks the inject script's idempotency checks into
@@ -143,7 +146,25 @@ else
     fi
 fi
 
-# 5. Verify patch was applied (functional test)
+# 5. Pre-verify state check: confirm each key marker is present before running functional test
+_state_ok() {
+    grep -q "$2" "$SHELLSPEC_DIR/$3" 2>/dev/null \
+        && log_info "  ✓ $1" \
+        || log_warn "  ✗ $1 (marker '$2' missing from $3)"
+}
+log_step "Pre-verify state check..."
+_state_ok "shellspec binary version"          "0.29.0-dev"               "shellspec"
+_state_ok "bootstrap.sh: timeout-parser"      "timeout-parser"           "lib/bootstrap.sh"
+_state_ok "outputs.sh: TIMEOUT function"      "shellspec_output_TIMEOUT" "lib/core/outputs.sh"
+_state_ok "directives: %timeout"              "timeout_metadata"         "lib/libexec/grammar/directives"
+_state_ok "optparser.sh: check_timeout"       "check_timeout_format"     "lib/libexec/optparser/optparser.sh"
+_state_ok "parser_definition.sh: TIMEOUT"     "TIMEOUT"                  "lib/libexec/optparser/parser_definition.sh"
+_state_ok "parser_definition_gen: TIMEOUT"    "SHELLSPEC_TIMEOUT"        "lib/libexec/optparser/parser_definition_generated.sh"
+_state_ok "translator.sh: timeout_override"   "shellspec_timeout_override" "lib/libexec/translator.sh"
+_state_ok "shellspec-translate.sh: EXAMPLE"   "SHELLSPEC_EXAMPLE_TIMEOUT" "libexec/shellspec-translate.sh"
+_state_ok "dsl.sh: watchdog invocation"       "shellspec-timeout-watchdog" "lib/core/dsl.sh"
+
+# 6. Verify patch was applied (functional test)
 log_step "Verifying timeout feature..."
 
 TEST_FILE="$SHELLSPEC_DIR/timeout_verification_spec.sh"
@@ -157,7 +178,7 @@ End
 EOF
 
 START_TIME=$(date +%s)
-"$SHELLSPEC_DIR/shellspec" "$TEST_FILE" >/dev/null 2>&1 || true
+_verify_out=$("$SHELLSPEC_DIR/shellspec" "$TEST_FILE" 2>&1) || true
 END_TIME=$(date +%s)
 DURATION=$((END_TIME - START_TIME))
 rm -f "$TEST_FILE"
@@ -169,5 +190,7 @@ if [[ $DURATION -lt 2 ]]; then
     exit 0
 else
     log_error "Verification failed: test did not timeout (Duration: ${DURATION}s, expected <2s)"
+    log_error "ShellSpec output from verification test:"
+    echo "$_verify_out" >&2
     exit 1
 fi

--- a/patches/apply.macos.sh
+++ b/patches/apply.macos.sh
@@ -2,8 +2,8 @@
 # Apply ShellSpec timeout patch (macOS)
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-02-10
-## Version: 3.0.0
+## Last revisit: 2026-02-23
+## Version: 3.1.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -111,10 +111,12 @@ if command -v patch >/dev/null 2>&1 && [[ -f "$PATCH_FILE" ]]; then
             patch_succeeded=true
         fi
     else
-        log_warn "Patch dry-run failed (source files differ from expected). Trying force-apply..."
-        # Force apply - will apply hunks that match, skip others
-        patch --batch --forward -p1 -N --fuzz=3 --force -i "$PATCH_FILE" 2>&1 || true
-        log_info "Force-apply done (some hunks may have been skipped)"
+        log_warn "Patch dry-run failed (source files differ from expected). Using direct injection..."
+        # Do NOT force-apply: --force with --fuzz on BSD patch (macOS) can write partial
+        # content to files (e.g. dsl.sh gets shellspec_timeout_seconds but not the watchdog
+        # invocation), which then tricks the inject script's idempotency checks into
+        # skipping those files and leaving the timeout feature broken.
+        # The inject script below is the correct robust fallback.
     fi
 
     # Clean up rejection/backup files

--- a/patches/inject-timeout.sh
+++ b/patches/inject-timeout.sh
@@ -3,8 +3,8 @@
 # Uses perl for portable multi-line text manipulation (available on macOS + Linux)
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
-## Last revisit: 2026-02-10
-## Version: 1.0.0
+## Last revisit: 2026-02-23
+## Version: 1.1.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -190,7 +190,9 @@ if ! grep -q "SHELLSPEC_EXAMPLE_TIMEOUT" "$SHELLSPEC_DIR/libexec/shellspec-trans
 fi
 
 # --- 11. dsl.sh: Add timeout execution logic (most complex modification) ---
-if ! grep -q "shellspec_timeout_seconds" "$SHELLSPEC_DIR/lib/core/dsl.sh" 2>/dev/null; then
+# Check for the watchdog invocation specifically - not just shellspec_timeout_seconds,
+# which can be partially written by 'patch --force' without the full functional logic.
+if ! grep -q "shellspec-timeout-watchdog" "$SHELLSPEC_DIR/lib/core/dsl.sh" 2>/dev/null; then
     log_info "Patching dsl.sh (timeout execution logic)..."
     perl -i -0777 -pe '
         # Match the original execution block pattern (flexible whitespace matching)

--- a/patches/inject-timeout.sh
+++ b/patches/inject-timeout.sh
@@ -4,7 +4,7 @@
 
 ## Copyright (C) 2017-present, Oleksandr Kucherenko
 ## Last revisit: 2026-02-23
-## Version: 1.1.0
+## Version: 1.2.0
 ## License: MIT
 ## Source: https://github.com/OleksandrKucherenko/e-bash
 
@@ -26,6 +26,8 @@ NC='\033[0m'
 log_info() { echo -e "${GREEN}[INJECT]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[INJECT]${NC} $*"; }
 log_error() { echo -e "${RED}[INJECT]${NC} $*" >&2; }
+log_skip() { echo -e "${YELLOW}[SKIP]${NC}   $*"; }
+log_ok()   { echo -e "${GREEN}[OK]${NC}     $*"; }
 
 # Verify perl is available
 if ! command -v perl >/dev/null 2>&1; then
@@ -43,11 +45,20 @@ cp "$FILES_DIR/lib/libexec/timeout-parser.sh" "$SHELLSPEC_DIR/lib/libexec/timeou
 cp "$FILES_DIR/libexec/shellspec-timeout-watchdog.sh" "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh"
 chmod +x "$SHELLSPEC_DIR/libexec/shellspec-timeout-watchdog.sh"
 
+_patched=0
+_skipped=0
+
 # --- 2. shellspec (main binary): Update version ---
 if grep -q "SHELLSPEC_VERSION='0.28" "$SHELLSPEC_DIR/shellspec" 2>/dev/null; then
     if ! grep -q "0.29.0-dev" "$SHELLSPEC_DIR/shellspec"; then
-        log_info "Updating version string..."
+        log_info "Patching shellspec: version string..."
         perl -i -pe "s/SHELLSPEC_VERSION='0\.28\.\d+'/SHELLSPEC_VERSION='0.29.0-dev'/" "$SHELLSPEC_DIR/shellspec"
+        grep -q "0.29.0-dev" "$SHELLSPEC_DIR/shellspec" \
+            && { log_ok "shellspec: version updated to 0.29.0-dev"; _patched=$((_patched + 1)); } \
+            || log_warn "shellspec: version update may have failed"
+    else
+        log_skip "shellspec: already at 0.29.0-dev"
+        _skipped=$((_skipped + 1))
     fi
 fi
 
@@ -60,6 +71,12 @@ if ! grep -q "timeout-parser" "$SHELLSPEC_DIR/lib/bootstrap.sh" 2>/dev/null; the
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/lib/bootstrap.sh"
+    grep -q "timeout-parser" "$SHELLSPEC_DIR/lib/bootstrap.sh" \
+        && { log_ok "bootstrap.sh: timeout-parser injected"; _patched=$((_patched + 1)); } \
+        || log_warn "bootstrap.sh: patch may have failed"
+else
+    log_skip "bootstrap.sh: timeout-parser already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 4. outputs.sh: Add TIMEOUT output function ---
@@ -71,12 +88,24 @@ if ! grep -q "shellspec_output_TIMEOUT" "$SHELLSPEC_DIR/lib/core/outputs.sh" 2>/
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/lib/core/outputs.sh"
+    grep -q "shellspec_output_TIMEOUT" "$SHELLSPEC_DIR/lib/core/outputs.sh" \
+        && { log_ok "outputs.sh: TIMEOUT function injected"; _patched=$((_patched + 1)); } \
+        || log_warn "outputs.sh: patch may have failed"
+else
+    log_skip "outputs.sh: shellspec_output_TIMEOUT already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 5. directives: Add %timeout ---
 if ! grep -q "timeout" "$SHELLSPEC_DIR/lib/libexec/grammar/directives" 2>/dev/null; then
     log_info "Patching directives..."
     echo '%timeout     => timeout_metadata' >> "$SHELLSPEC_DIR/lib/libexec/grammar/directives"
+    grep -q "timeout" "$SHELLSPEC_DIR/lib/libexec/grammar/directives" \
+        && { log_ok "directives: %timeout added"; _patched=$((_patched + 1)); } \
+        || log_warn "directives: patch may have failed"
+else
+    log_skip "directives: %timeout already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 6. optparser.sh: Add check_timeout_format ---
@@ -96,6 +125,12 @@ if ! grep -q "check_timeout_format" "$SHELLSPEC_DIR/lib/libexec/optparser/optpar
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/lib/libexec/optparser/optparser.sh"
+    grep -q "check_timeout_format" "$SHELLSPEC_DIR/lib/libexec/optparser/optparser.sh" \
+        && { log_ok "optparser.sh: check_timeout_format injected"; _patched=$((_patched + 1)); } \
+        || log_warn "optparser.sh: patch may have failed"
+else
+    log_skip "optparser.sh: check_timeout_format already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 7. parser_definition.sh: Add --timeout options ---
@@ -107,6 +142,12 @@ if ! grep -q "TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition.s
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition.sh"
+    grep -q "TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition.sh" \
+        && { log_ok "parser_definition.sh: TIMEOUT option injected"; _patched=$((_patched + 1)); } \
+        || log_warn "parser_definition.sh: patch may have failed"
+else
+    log_skip "parser_definition.sh: TIMEOUT already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 8. parser_definition_generated.sh: The big one - add exports + CLI parsing + help text ---
@@ -154,6 +195,12 @@ if ! grep -q "SHELLSPEC_TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_de
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh"
+    grep -q "SHELLSPEC_TIMEOUT" "$SHELLSPEC_DIR/lib/libexec/optparser/parser_definition_generated.sh" \
+        && { log_ok "parser_definition_generated.sh: SHELLSPEC_TIMEOUT injected"; _patched=$((_patched + 1)); } \
+        || log_warn "parser_definition_generated.sh: patch may have failed"
+else
+    log_skip "parser_definition_generated.sh: SHELLSPEC_TIMEOUT already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 9. translator.sh: Add timeout override parsing ---
@@ -176,6 +223,12 @@ $1}ms;
 
         s{(^include\(\)\s*\{)}{timeout_metadata() {\n  :\n}\n\n$1}ms;
     ' "$SHELLSPEC_DIR/lib/libexec/translator.sh"
+    grep -q "shellspec_timeout_override" "$SHELLSPEC_DIR/lib/libexec/translator.sh" \
+        && { log_ok "translator.sh: timeout_override injected"; _patched=$((_patched + 1)); } \
+        || log_warn "translator.sh: patch may have failed"
+else
+    log_skip "translator.sh: shellspec_timeout_override already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 10. shellspec-translate.sh: Inject SHELLSPEC_EXAMPLE_TIMEOUT ---
@@ -187,6 +240,12 @@ if ! grep -q "SHELLSPEC_EXAMPLE_TIMEOUT" "$SHELLSPEC_DIR/libexec/shellspec-trans
             $done = 1;
         }
     ' "$SHELLSPEC_DIR/libexec/shellspec-translate.sh"
+    grep -q "SHELLSPEC_EXAMPLE_TIMEOUT" "$SHELLSPEC_DIR/libexec/shellspec-translate.sh" \
+        && { log_ok "shellspec-translate.sh: EXAMPLE_TIMEOUT injected"; _patched=$((_patched + 1)); } \
+        || log_warn "shellspec-translate.sh: patch may have failed"
+else
+    log_skip "shellspec-translate.sh: SHELLSPEC_EXAMPLE_TIMEOUT already present"
+    _skipped=$((_skipped + 1))
 fi
 
 # --- 11. dsl.sh: Add timeout execution logic (most complex modification) ---
@@ -270,10 +329,19 @@ $2$3
 }xms' "$SHELLSPEC_DIR/lib/core/dsl.sh"
 
     # Verify the dsl.sh modification worked
-    if ! grep -q "shellspec_timeout_seconds" "$SHELLSPEC_DIR/lib/core/dsl.sh"; then
-        log_warn "dsl.sh regex match failed - timeout per-example may not work"
-        log_warn "This is OK if the patch command already applied this hunk"
+    if grep -q "shellspec-timeout-watchdog" "$SHELLSPEC_DIR/lib/core/dsl.sh"; then
+        log_ok "dsl.sh: timeout execution logic injected"
+        _patched=$((_patched + 1))
+    else
+        log_warn "dsl.sh: perl regex did not match - per-example timeout will NOT work"
+        log_warn "Expected to find 'shellspec_invoke_example 3>&2' block near 'shellspec_profile_start'."
+        log_warn "Actual surrounding context in dsl.sh (for diagnosis):"
+        grep -n "shellspec_invoke_example\|shellspec_profile_start\|set +e" \
+            "$SHELLSPEC_DIR/lib/core/dsl.sh" 2>/dev/null | head -10 >&2 || true
     fi
+else
+    log_skip "dsl.sh: shellspec-timeout-watchdog already present"
+    _skipped=$((_skipped + 1))
 fi
 
-log_info "Direct injection complete"
+log_info "Direct injection complete ($_patched patched, $_skipped skipped)"


### PR DESCRIPTION
## Summary
Enhanced the ShellSpec timeout patch application scripts with better error handling, diagnostic output, and idempotency checks. Replaced unreliable force-apply fallback with direct injection method and added comprehensive state verification.

## Key Changes

### inject-timeout.sh (v1.0.0 → v1.2.0)
- Added two new logging functions: `log_skip()` and `log_ok()` for better status reporting
- Implemented patch tracking with `_patched` and `_skipped` counters to report results
- Added verification checks after each patch operation to confirm successful application
- Enhanced dsl.sh detection to check for `shellspec-timeout-watchdog` invocation instead of just `shellspec_timeout_seconds` (more reliable marker)
- Improved dsl.sh failure diagnostics with context output showing surrounding code
- Updated final summary to display patch and skip counts

### apply.macos.sh & apply.linux.sh (v3.0.0 → v3.2.0)
- Removed unreliable `patch --force` fallback that could write partial content to files
- Changed strategy: when patch dry-run fails, now uses direct injection script instead of force-apply
- Added dry-run output capture and diagnostic logging of failed hunks
- Implemented comprehensive pre-verification state check (`_state_ok()` function) that validates 10 key markers before running functional tests
- Enhanced verification test output capture to display ShellSpec output on failure
- Improved error messages with specific guidance about what went wrong

### bin/wsl/xdg-open.sh
- Extended pwsh launcher detection to recognize additional naming patterns: `"pwsh (scoop)"` and `"pwsh (winget)"` alongside existing variants
- Updated both `xdg:launcher:exe()` and `xdg:launcher:path()` functions for consistency

## Notable Implementation Details

The key improvement is replacing the problematic `patch --force` approach with a two-stage strategy:
1. **Normal patch attempt** with dry-run validation
2. **Direct injection fallback** using the inject-timeout.sh script when patch fails

This prevents partial file modifications that could mask incomplete patches. The new pre-verification state check validates all 10 critical markers are present before running the functional timeout test, providing clear diagnostics if any component is missing.

https://claude.ai/code/session_01KULS9qiYX5yhw68UAKCqgP

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR significantly improves the robustness and diagnostics of ShellSpec timeout patch application scripts. The key improvement is replacing the problematic `patch --force` fallback with a two-stage strategy that prevents partial file modifications.

**Major Changes:**
- **Removed dangerous `patch --force` fallback**: The force-apply approach could write partial content to files (e.g., `dsl.sh` getting `shellspec_timeout_seconds` but not the watchdog invocation), which would trick idempotency checks into skipping files and leaving the timeout feature broken
- **Enhanced inject-timeout.sh diagnostics**: Added `log_skip()` and `log_ok()` functions, patch/skip counters, and verification checks after each operation. Changed `dsl.sh` detection to check for `shellspec-timeout-watchdog` invocation instead of just `shellspec_timeout_seconds`
- **Comprehensive pre-verification**: Both apply scripts now validate 10 critical markers are present before running functional timeout tests, providing clear diagnostics if components are missing
- **Better error output**: Captures and displays dry-run output showing failed hunks, and displays ShellSpec test output on verification failures
- **xdg-open.sh compatibility**: Extended pwsh launcher detection to recognize additional naming patterns from Scoop/Winget installations

All changes follow established bash scripting standards with proper error handling, set -euo pipefail, and comprehensive logging. The version bumps (v1.0.0→v1.2.0 for inject-timeout.sh, v3.0.0→v3.2.0 for apply scripts) are appropriate for the scope of changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- All changes improve robustness, error handling, and diagnostics without introducing new risks. The removal of `patch --force` eliminates a known source of silent failures. Code follows established patterns, includes proper validation, and maintains idempotency. Changes are well-documented with clear comments explaining the rationale.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| patches/inject-timeout.sh | Added comprehensive logging (`log_skip`, `log_ok`), patch/skip counters, verification checks after each operation, and improved `dsl.sh` detection to check for `shellspec-timeout-watchdog` invocation (more reliable than `shellspec_timeout_seconds`) |
| patches/apply.macos.sh | Removed unreliable `patch --force` fallback, added dry-run diagnostic capture, implemented comprehensive pre-verification state check with 10 markers, enhanced error output with ShellSpec test results |
| patches/apply.linux.sh | Removed unreliable `patch --force` fallback, added dry-run diagnostic capture, implemented comprehensive pre-verification state check with 10 markers, enhanced error output with ShellSpec test results |
| bin/wsl/xdg-open.sh | Extended pwsh launcher detection to recognize `"pwsh (scoop)"` and `"pwsh (winget)"` identifier patterns in both `xdg:launcher:exe()` and `xdg:launcher:path()` functions |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([Apply Patch Script]) --> FindShellSpec[Find ShellSpec Directory]
    FindShellSpec --> CheckMarker{Marker File or<br/>--timeout flag exists?}
    CheckMarker -->|Yes| Exit1([Exit: Already Patched])
    CheckMarker -->|No| PatchAvail{Patch Command<br/>Available?}
    
    PatchAvail -->|Yes| DryRun[Run Patch --dry-run]
    PatchAvail -->|No| DirectInject
    
    DryRun --> DryRunOK{Dry-run<br/>Successful?}
    DryRunOK -->|Yes| ApplyPatch[Apply Patch]
    DryRunOK -->|No| LogFailedHunks[Log Failed Hunks<br/>from dry-run output]
    
    ApplyPatch --> PatchSuccess{Patch<br/>Applied?}
    PatchSuccess -->|Yes| CopyFiles[Copy New Files<br/>timeout-parser.sh<br/>watchdog.sh]
    PatchSuccess -->|No| DirectInject
    
    LogFailedHunks --> DirectInject[Run inject-timeout.sh<br/>Direct Injection]
    
    DirectInject --> InjectFiles[Copy New Files +<br/>Modify Existing Files<br/>via Perl]
    InjectFiles --> VerifyEach[Verify Each Injection<br/>with grep checks]
    VerifyEach --> InjectStats[Report Patched/Skipped<br/>Counts]
    
    CopyFiles --> PreVerify[Pre-verification<br/>State Check]
    InjectStats --> PreVerify
    
    PreVerify --> Check10[Validate 10 Markers:<br/>- shellspec version<br/>- bootstrap timeout-parser<br/>- outputs TIMEOUT func<br/>- directives timeout<br/>- optparser check_timeout<br/>- parser_definition TIMEOUT<br/>- parser_gen SHELLSPEC_TIMEOUT<br/>- translator timeout_override<br/>- translate EXAMPLE_TIMEOUT<br/>- dsl.sh watchdog invocation]
    
    Check10 --> FunctionalTest[Functional Test:<br/>Run timeout test<br/>expect duration < 2s]
    
    FunctionalTest --> TestOK{Test<br/>Passed?}
    TestOK -->|Yes| CreateMarker[Create Marker File]
    TestOK -->|No| LogTestOutput[Log ShellSpec Output]
    
    CreateMarker --> Exit2([Exit: Success])
    LogTestOutput --> Exit3([Exit: Failure])
    
    style DirectInject fill:#ffeb3b
    style Check10 fill:#4caf50,color:#fff
    style LogFailedHunks fill:#ff9800
    style LogTestOutput fill:#f44336,color:#fff
```

<sub>Last reviewed commit: 5657476</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->